### PR TITLE
let envinject support new job types

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectListener.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectListener.java
@@ -79,10 +79,7 @@ public class EnvInjectListener extends RunListener<Run> implements Serializable 
             job = build.getParent();
         }
 
-        return job instanceof FreeStyleProject
-                || job instanceof MatrixProject
-                || job instanceof AbstractMavenProject
-                || (Hudson.getInstance().getPlugin("ivy") != null && job instanceof hudson.ivy.IvyModuleSet);
+        return job instanceof BuildableItemWithBuildWrappers;
 
     }
 

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/BuildWrapperService.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/BuildWrapperService.java
@@ -63,15 +63,9 @@ public class BuildWrapperService implements Serializable {
             return project.getBuildWrappersList();
         } else {
             AbstractProject abstractProject = build.getProject();
-            if (abstractProject instanceof FreeStyleProject) {
-                Project project = (Project) abstractProject;
+            if (abstractProject instanceof BuildableItemWithBuildWrappers) {
+                BuildableItemWithBuildWrappers project = (BuildableItemWithBuildWrappers) abstractProject;
                 return project.getBuildWrappersList();
-            } else if (abstractProject instanceof MavenModuleSet) {
-                MavenModuleSet moduleSet = (MavenModuleSet) abstractProject;
-                return moduleSet.getBuildWrappersList();
-            } else if (Hudson.getInstance().getPlugin("ivy") != null && abstractProject instanceof hudson.ivy.IvyModuleSet) {
-                hudson.ivy.IvyModuleSet ivyModuleSet = (hudson.ivy.IvyModuleSet) abstractProject;
-                return ivyModuleSet.getBuildWrappersList();
             } else {
                 throw new EnvInjectException(String.format("Job type %s is not supported", abstractProject));
             }

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectPasswordsMasker.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectPasswordsMasker.java
@@ -76,15 +76,9 @@ public class EnvInjectPasswordsMasker implements Serializable {
             wrappersProject = project.getBuildWrappersList();
         } else {
             AbstractProject abstractProject = build.getProject();
-            if (abstractProject instanceof FreeStyleProject) {
-                Project project = (Project) abstractProject;
+            if (abstractProject instanceof BuildableItemWithBuildWrappers) {
+                BuildableItemWithBuildWrappers project = (BuildableItemWithBuildWrappers) abstractProject;
                 wrappersProject = project.getBuildWrappersList();
-            } else if (abstractProject instanceof MavenModuleSet) {
-                MavenModuleSet moduleSet = (MavenModuleSet) abstractProject;
-                wrappersProject = moduleSet.getBuildWrappersList();
-            } else if (Hudson.getInstance().getPlugin("ivy") != null && abstractProject instanceof hudson.ivy.IvyModuleSet) {
-                hudson.ivy.IvyModuleSet ivyModuleSet = (hudson.ivy.IvyModuleSet) abstractProject;
-                wrappersProject = ivyModuleSet.getBuildWrappersList();
             } else {
                 throw new EnvInjectException(String.format("Job type %s is not supported", abstractProject));
             }


### PR DESCRIPTION
replace "white-list" strategy for supported job types by use of BuildableItemWithBuildWrappers interface to access the job's buildWrapper list.
