### PR TITLE
Retain line break characters in property values.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/util/SortedProperties.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/util/SortedProperties.java
@@ -73,6 +73,9 @@ public class SortedProperties extends LinkedHashMap<Object, Object> {
                     if (!appendedLineBegin && (c == '\r' || c == '\n')) {
                         continue;
                     }
+                    if (appendedLineBegin) {
+                        lineBuf[len++] = '\n';
+                    }
                     skipWhiteSpace = false;
                     appendedLineBegin = false;
                 }

--- a/src/test/java/org/jenkinsci/plugins/envinject/sevice/PropertiesLoaderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/sevice/PropertiesLoaderTest.java
@@ -115,6 +115,29 @@ public class PropertiesLoaderTest {
     }
 
     @Test
+    public void fileWithNewlineInValues() throws Exception {
+        checkWithNewlineInValues(true);
+    }
+
+    @Test
+    public void contentWithNewlineInValues() throws Exception {
+        checkWithNewlineInValues(false);
+    }
+
+    private void checkWithNewlineInValues(boolean fromFile) throws Exception {
+        // Create properties file containing backslash-escaped newlines
+        String content = "KEY1=line1\\\nline2\nKEY2= line1 \\\n line2 \nKEY3=line1\\\n\\\nline3";
+        Map<String, String> gatherVars = gatherEnvVars(fromFile, content, new HashMap<String, String>());
+        assertNotNull(gatherVars);
+        assertTrue(gatherVars.size() == 3);
+
+        // Values should be trimmed at start & end, otherwise whitespace & newlines should be kept
+        assertEquals("line1\nline2", gatherVars.get("KEY1"));
+        assertEquals("line1 \nline2", gatherVars.get("KEY2"));
+        assertEquals("line1\n\nline3", gatherVars.get("KEY3"));
+    }
+
+    @Test
     public void fileWithVarsToResolve() throws Exception {
         checkWithVarsToResolve(true);
     }


### PR DESCRIPTION
When loading a property file like this into the environment, the backslashes are recognised properly and the value is correctly loaded, but the newline characters are missing.
So this property file

```
CHANGELOG=* Fixed this. \
 * Fixed that. \
 * Fixed something else.
```

causes this to be added to the Jenkins environment:

```
CHANGELOG=* Fixed this. * Fixed that. * Fixed something else.
```

This doesn't seem like the correct behaviour, and Jenkins seems to work fine with multi-line environment variables set elsewhere, so this pull request adds the newlines to the value where appropriate.

I added a couple of test cases for this which pass, along with the existing test suite.

We're using this in a couple of jobs, using the newline-containing value with various plugins and it works fine.
