### PR TITLE
[NO_MERGE] [JENKINS-16316] - Bug fix and additional tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -43,12 +43,30 @@
         <ivy.plugin.version>1.21</ivy.plugin.version>
         <junit.version>4.9</junit.version>
         <mockito.version>1.8.5</mockito.version>
+        <powermock.version>1.4.9</powermock.version>
     </properties>
 
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/envinject-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/envinject-plugin.git</developerConnection>
     </scm>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.14.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit4</artifactId>
+                        <version>2.14.1</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <dependency>
@@ -82,6 +100,15 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-mockito-release-full</artifactId>
+            <version>${powermock.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <repositories>
@@ -98,6 +125,6 @@
         </pluginRepository>
     </pluginRepositories>
 
-</project>  
-  
+</project>
+
 

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectListener.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectListener.java
@@ -246,7 +246,7 @@ public class EnvInjectListener extends RunListener<Run> implements Serializable 
         };
     }
 
-    private Environment setUpEnvironmentWithoutJobPropertyObject(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException, EnvInjectException {
+    protected Environment setUpEnvironmentWithoutJobPropertyObject(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException, EnvInjectException {
 
         final Map<String, String> resultVariables = new HashMap<String, String>();
 
@@ -255,7 +255,7 @@ public class EnvInjectListener extends RunListener<Run> implements Serializable 
         Map<String, String> previousEnvVars = variableGetter.getEnvVarsPreviousSteps(build, logger);
         resultVariables.putAll(previousEnvVars);
 
-        resultVariables.putAll(variableGetter.getJenkinsSystemVariables(true));
+        resultVariables.putAll(variableGetter.getJenkinsSystemVariables(false));
         resultVariables.putAll(variableGetter.getBuildVariables(build, logger));
 
         final FilePath rootPath = getNodeRootPath();

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectVariableGetter.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectVariableGetter.java
@@ -1,10 +1,9 @@
 package org.jenkinsci.plugins.envinject.service;
 
-import hudson.EnvVars;
 import hudson.Util;
 import hudson.matrix.MatrixRun;
 import hudson.model.*;
-import hudson.util.LogTaskListener;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 import org.jenkinsci.lib.envinject.EnvInjectLogger;
 import org.jenkinsci.plugins.envinject.EnvInjectJobProperty;
@@ -16,7 +15,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -53,6 +51,12 @@ public class EnvInjectVariableGetter {
         }
         result.put("JENKINS_HOME", Hudson.getInstance().getRootDir().getPath());
         result.put("HUDSON_HOME", Hudson.getInstance().getRootDir().getPath());   // legacy compatibility
+
+        List<EnvironmentVariablesNodeProperty> globalNodeProperties = Hudson.getInstance().getGlobalNodeProperties()
+            .getAll(EnvironmentVariablesNodeProperty.class);
+        for (EnvironmentVariablesNodeProperty environmentVariablesNodeProperty : globalNodeProperties) {
+            result.putAll(environmentVariablesNodeProperty.getEnvVars());
+        }
 
         return result;
     }

--- a/src/test/java/org/jenkinsci/plugins/envinject/sevice/EnvInjectVariableGetterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/sevice/EnvInjectVariableGetterTest.java
@@ -1,23 +1,41 @@
 package org.jenkinsci.plugins.envinject.sevice;
 
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import hudson.EnvVars;
 import hudson.matrix.MatrixRun;
 import hudson.model.AbstractBuild;
+import hudson.model.Computer;
+import hudson.model.Hudson;
+import hudson.model.Node;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodePropertyDescriptor;
+import hudson.util.DescribableList;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import junit.framework.Assert;
+
 import org.jenkinsci.lib.envinject.EnvInjectLogger;
 import org.jenkinsci.plugins.envinject.EnvInjectPluginAction;
 import org.jenkinsci.plugins.envinject.service.EnvInjectVariableGetter;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * @author Gregory Boissinot
  */
+@RunWith(PowerMockRunner.class)
 public class EnvInjectVariableGetterTest {
 
     private EnvInjectVariableGetter variableGetter;
@@ -65,6 +83,40 @@ public class EnvInjectVariableGetterTest {
         assertTrue(sameMap(expectedEnvVars, resultEnvVars));
     }
 
+    @Test
+    @PrepareForTest({ Computer.class, Hudson.class })
+    public void testGetJenkinsSystemVariablesForceFetchesGlobalNodesPropertiesFromMaster() throws Exception {
+
+        PowerMockito.mockStatic(Computer.class);
+        PowerMockito.mockStatic(Hudson.class);
+        Computer computer = mock(Computer.class);
+        Node node = mock(Node.class);
+        EnvVars envVars = new EnvVars();
+        final String PROPERTY_KEY = "PATH";
+        final String VALUE_FROM_SLAVE_COMPUTER = "VALUE_FROM_SLAVE_COMPUTER";
+        final String VALUE_FROM_GNP_MASTER = "VALUE_FROM_GNP_MASTER";
+        envVars.put(PROPERTY_KEY, VALUE_FROM_SLAVE_COMPUTER);
+        Hudson hudson = mock(Hudson.class);
+
+        when(Computer.currentComputer()).thenReturn(computer);
+        when(computer.getNode()).thenReturn(node);
+        when(computer.getEnvironment()).thenReturn(envVars);
+        when(node.getAssignedLabels()).thenReturn(new HashSet<LabelAtom>());
+        when(computer.getName()).thenReturn("slave0");
+        when(Hudson.getInstance()).thenReturn(hudson);
+        when(hudson.getRootDir()).thenReturn(new File(""));
+
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> globalNodeProperties = new DescribableList<NodeProperty<?>, NodePropertyDescriptor>(
+            hudson);
+        EnvironmentVariablesNodeProperty property = new EnvironmentVariablesNodeProperty(
+            new EnvironmentVariablesNodeProperty.Entry(PROPERTY_KEY, VALUE_FROM_GNP_MASTER));
+        globalNodeProperties.add(property);
+        when(Hudson.getInstance().getGlobalNodeProperties()).thenReturn(globalNodeProperties);
+
+        Map<String, String> jenkinsSystemVariables = variableGetter.getJenkinsSystemVariables(false);
+        Assert.assertNotNull(jenkinsSystemVariables);
+        Assert.assertEquals(VALUE_FROM_GNP_MASTER, jenkinsSystemVariables.get(PROPERTY_KEY));
+    }
 
     private boolean sameMap(Map<String, String> expectedMap, Map<String, String> actualMap) {
 


### PR DESCRIPTION
slave (which are outdated if you dont restart slave nodes after changing
global properties)

CAUTION - this might break some features: EnvironmentContributors don't
get recognized any more (because CoreEnvironmentContributor did a
Computer.current.getEnvironment() which also leads to overwriting with
outdated values.

how to reproduce the problem:
hpi:run on current head with jenkins-version set to "1.480.3" (current LTS verison)
configure a global property on master K/V: TESTVAR/value1
configure a slave and start it
configure a job restricted to run on that slave and to echo $TESTVAR.
run the job (it will echo "value1")
configure the global property on master to be: TESTVAR/value2
dont restart anything
rerun the job (it will still echo "value1")
however a job on master will recognize the changed value.
there are 2 pieces of code that lead to this behaviour. I'm pretty uncertain about the fix i made, but it resolves at least our problem with the plugin as i described it above, although i'm pretty sure it breaks some other intended feature.
https://github.com/kazesberger/envinject-plugin.git
https://github.com/kazesberger/envinject-plugin/commits/master
maybe someone can have a look at it and/or tell me what's the story behind this (Core)EnvironmentContributor thing.
