### PR TITLE
[JENKINS-14144] only register buildWrapper when required

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectJobProperty.java
@@ -28,8 +28,9 @@ public class EnvInjectJobProperty<T extends Job<?, ?>> extends JobProperty<T> {
     private boolean on;
     private boolean keepJenkinsSystemVariables;
     private boolean keepBuildVariables;
-    private EnvInjectJobPropertyContributor[] contributors;
+    private Boolean setBeforeCheckout = Boolean.FALSE;
 
+    private EnvInjectJobPropertyContributor[] contributors;
     private transient EnvInjectJobPropertyContributor[] contributorsComputed;
 
     @SuppressWarnings("unused")
@@ -102,6 +103,11 @@ public class EnvInjectJobProperty<T extends Job<?, ?>> extends JobProperty<T> {
         this.info = info;
     }
 
+    public Object readResolve() {
+        if (setBeforeCheckout == null) setBeforeCheckout = true;
+        return this;
+    }
+
     public void setOn(boolean on) {
         this.on = on;
     }
@@ -130,6 +136,14 @@ public class EnvInjectJobProperty<T extends Job<?, ?>> extends JobProperty<T> {
                                                          property.info.isLoadFilesFromMaster());
         }
         return property;
+    }
+
+    public boolean isSetBeforeCheckout() {
+        return setBeforeCheckout;
+    }
+
+    public void setSetBeforeCheckout(boolean setBeforeCheckout) {
+        this.setBeforeCheckout = setBeforeCheckout;
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectListener.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectListener.java
@@ -228,9 +228,11 @@ public class EnvInjectListener extends RunListener<Run> implements Serializable 
             //Add an action to share injected environment variables
             new EnvInjectActionSetter(rootPath).addEnvVarsToEnvInjectBuildAction(build, mergedVariables);
 
-            //Add a wrapper to intercept the preCheckout event and add specific variables such as WORKSPACE variable
-            BuildWrapperService wrapperService = new BuildWrapperService();
-            wrapperService.addBuildWrapper(build, new JobSetupEnvironmentWrapper());
+            if (envInjectJobProperty.isSetBeforeCheckout()) {
+                //Add a wrapper to intercept the preCheckout event and add specific variables such as WORKSPACE variable
+                BuildWrapperService wrapperService = new BuildWrapperService();
+                wrapperService.addBuildWrapper(build, new JobSetupEnvironmentWrapper());
+            }
 
 
             return new Environment() {

--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectJobProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectJobProperty/config.jelly
@@ -5,16 +5,16 @@
                      checked="${instance.on}"
                      help="/plugin/envinject/help.html">
 
+        <f:entry field="setBeforeCheckout" title="${%Set variables before checkout}">
+            <f:checkbox default="${false}"/>
+        </f:entry>
+
         <f:entry field="keepJenkinsSystemVariables" title="${%Keep Jenkins Environment Variables}">
-            <f:checkbox
-                    name="keepJenkinsSystemVariables"
-                    checked="${instance.keepJenkinsSystemVariables}" default="${true}"/>
+            <f:checkbox default="${true}"/>
         </f:entry>
 
         <f:entry field="keepBuildVariables" title="${%Keep Jenkins Build Variables}">
-            <f:checkbox
-                    name="keepBuildVariables"
-                    checked="${instance.keepBuildVariables}" default="${true}"/>
+            <f:checkbox default="${true}"/>
         </f:entry>
 
         <f:entry title="${%Script File Path}"

--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectJobProperty/help-setBeforeCheckout.html
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectJobProperty/help-setBeforeCheckout.html
@@ -1,0 +1,3 @@
+<p>
+    If set, envinject will set environment before SCM checkout occurs (preCheckout).
+</p>


### PR DESCRIPTION
adding a buildWrapper trigger project.save() that has impacts on job history plugins.
This is only a workaround, to register (technical) buildWrapper only when required
