### PR TITLE
[JENKINS-16316] Changes to global variables not honored.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectComputerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectComputerListener.java
@@ -77,13 +77,6 @@ public class EnvInjectComputerListener extends ComputerListener implements Seria
 
         Map<String, String> currentEnvVars = new HashMap<String, String>();
 
-        // -- Retrieve Environment variables from master
-        for (NodeProperty<?> nodeProperty : Hudson.getInstance().getGlobalNodeProperties()) {
-            if (nodeProperty instanceof EnvironmentVariablesNodeProperty) {
-                currentEnvVars.putAll(((EnvironmentVariablesNodeProperty) nodeProperty).getEnvVars());
-            }
-        }
-
         EnvInjectLogger logger = new EnvInjectLogger(listener);
         EnvInjectEnvVars envInjectEnvVarsService = new EnvInjectEnvVars(logger);
 


### PR DESCRIPTION
Seems to fix [JENKINS-16316](https://issues.jenkins-ci.org/browse/JENKINS-16316). When `EnvInjectComputerListener.onOnline` considers `Jenkins.globalNodeProperties`, it takes the initial values of these variables and stuffs them into `masterEnvVars` on the slave, which really ought to be limited to “natural” environment variables. Then when these variables are changed and a build runs, the old values from `masterEnvVars` take precedence. This is true even if the user has never done anything with the EnvInject plugin except install it—especially insidious.

Pull #14 also claims to fix the same bug, in a very different way. Even if that is rejected, its tests may be useful.
