### PR TITLE
update hpi plugin, to ease development with eclipse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,17 @@
         <developerConnection>scm:git:git@github.com:jenkinsci/envinject-plugin.git</developerConnection>
     </scm>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jenkins-ci.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <version>1.98</version>
+                <extensions>true</extensions>
+            </plugin>        
+        </plugins>
+    </build>
+    
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>


### PR DESCRIPTION
This PR only updates the maven-hpi-plugin, this makes it a lot easier to work on this plugin with eclipse...
