### PR TITLE
Execute Groovy scripts and injecting environment variables after SCM

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectBuildWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectBuildWrapper/config.jelly
@@ -28,6 +28,13 @@
                 value="${instance.info.scriptContent}"/>
     </f:entry>
 
+    <f:entry title="${%Evaluated Groovy script}"
+            help="/descriptor/org.jenkinsci.plugins.envinject.EnvInjectJobProperty/help/groovyScriptContent">
+        <f:textarea
+                name="envInjectInfoWrapper.groovyScriptContent"
+                value="${instance.info.groovyScriptContent}"/>
+    </f:entry>
+
     <f:hidden
             name="envInjectInfoWrapper.loadFilesFromMaster"
             value="false"/>


### PR DESCRIPTION
Currently, this plugin doesn't support Execute Groovy scripts after the SCM step in Build Wrapper.

added few lines to fix it.
