### PR TITLE
[JENKINS-22126] override build parameters only when explicitly requested

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuildVariableContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuildVariableContributor.java
@@ -4,6 +4,7 @@ import hudson.Extension;
 import hudson.model.*;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 import org.jenkinsci.lib.envinject.EnvInjectLogger;
+import org.jenkinsci.plugins.envinject.service.EnvInjectVariableGetter;
 import org.jenkinsci.plugins.envinject.service.EnvironmentVariablesNodeLoader;
 
 import java.util.HashMap;
@@ -24,6 +25,15 @@ public class EnvInjectBuildVariableContributor extends BuildVariableContributor 
         ParametersAction parameters = build.getAction(ParametersAction.class);
         //Only for a parameterized job
         if (parameters != null) {
+
+            EnvInjectVariableGetter variableGetter = new EnvInjectVariableGetter();
+            EnvInjectJobProperty envInjectJobProperty = variableGetter.getEnvInjectJobProperty(build);
+            if (envInjectJobProperty == null) {
+                // Don't override anything if envinject isn't enabled on this job
+                return;
+            }
+
+            if (!envInjectJobProperty.isOverrideBuildParameters()) return;
 
             //Gather global variables for the current node
             EnvironmentVariablesNodeLoader environmentVariablesNodeLoader = new EnvironmentVariablesNodeLoader();

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectJobProperty.java
@@ -28,6 +28,7 @@ public class EnvInjectJobProperty<T extends Job<?, ?>> extends JobProperty<T> {
     private boolean on;
     private boolean keepJenkinsSystemVariables;
     private boolean keepBuildVariables;
+    private boolean overrideBuildParameters;
     private EnvInjectJobPropertyContributor[] contributors;
 
     private transient EnvInjectJobPropertyContributor[] contributorsComputed;
@@ -50,6 +51,11 @@ public class EnvInjectJobProperty<T extends Job<?, ?>> extends JobProperty<T> {
     @SuppressWarnings("unused")
     public boolean isKeepBuildVariables() {
         return keepBuildVariables;
+    }
+
+    @SuppressWarnings("unused")
+    public boolean isOverrideBuildParameters() {
+        return overrideBuildParameters;
     }
 
     @SuppressWarnings("unused")
@@ -114,10 +120,13 @@ public class EnvInjectJobProperty<T extends Job<?, ?>> extends JobProperty<T> {
         this.keepBuildVariables = keepBuildVariables;
     }
 
+    public void setOverrideBuildParameters(boolean overrideBuildParameters) {
+        this.overrideBuildParameters = overrideBuildParameters;
+    }
+
     public void setContributors(EnvInjectJobPropertyContributor[] jobPropertyContributors) {
         this.contributors = jobPropertyContributors;
     }
-
 
     @Override
     public JobProperty<?> reconfigure(StaplerRequest req, JSONObject form) throws Descriptor.FormException {
@@ -164,6 +173,7 @@ public class EnvInjectJobProperty<T extends Job<?, ?>> extends JobProperty<T> {
                     JSONObject onJSONObject = (JSONObject) onObject;
                     envInjectJobProperty.setKeepJenkinsSystemVariables(onJSONObject.getBoolean("keepJenkinsSystemVariables"));
                     envInjectJobProperty.setKeepBuildVariables(onJSONObject.getBoolean("keepBuildVariables"));
+                    envInjectJobProperty.setOverrideBuildParameters(onJSONObject.getBoolean("overrideBuildParameters"));
 
                     //Process contributions
                     setContributors(req, envInjectJobProperty, onJSONObject);

--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectJobProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectJobProperty/config.jelly
@@ -17,6 +17,13 @@
                     checked="${instance.keepBuildVariables}" default="${true}"/>
         </f:entry>
 
+        <f:entry field="overrideBuildParameters" title="${%Override Build Parameters}">
+            <f:checkbox
+                    name="overrideBuildParameters"
+                    checked="${instance.overrideBuildParameters}" default="${false}"/>
+        </f:entry>
+
+
         <f:entry title="${%Script File Path}"
                  help="/descriptor/org.jenkinsci.plugins.envinject.EnvInjectJobProperty/help/scriptFilePath">
             <f:textbox


### PR DESCRIPTION
add a configuration option to explicitly ask envinject to override build parameters. Don't override by default and don't override when envinject isn't used on jobs.
