### PR TITLE
[FIXED JENKINS-24130] - Added an option to mask PasswordParameters

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectPasswordWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectPasswordWrapper/config.jelly
@@ -37,4 +37,11 @@
 
     </f:entry>
 
+    <f:entry field="maskPasswordParameters"
+             title="${%Mask password parameters}"
+             help="/plugin/envinject/help-buildWrapperMaskPasswordParameters.html">
+        <f:checkbox
+                name="maskPasswordParameters"
+                checked="${instance.maskPasswordParameters}" default="${true}"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/webapp/help-buildWrapperMaskPasswordParameters.html
+++ b/src/main/webapp/help-buildWrapperMaskPasswordParameters.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        Mask passwords provided by build parameters. <br/>
+    </p>
+</div>


### PR DESCRIPTION
This is a straightforward implementation, an additional re-factoring would be useful.
The option is enabled by default, but this behavior can be changed in order to prevent any compatibility issues.

Signed-off-by: Oleg Nenashev o.v.nenashev@gmail.com
