### PR TITLE
[FIXED JENKINS-24785] - Introduce ROOT_BUILD_CAUSE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.445</version>
+        <version>1.482</version>
     </parent>
 
     <artifactId>envinject</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/BuildCauseRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/BuildCauseRetriever.java
@@ -7,36 +7,70 @@ import hudson.triggers.SCMTrigger;
 import hudson.triggers.TimerTrigger;
 import org.apache.commons.lang.StringUtils;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Gregory Boissinot
  */
 public class BuildCauseRetriever {
 
+    /**
+     * Maximum depth of transitive upstream causes we want to record.
+     */
+    private static final int MAX_UPSTREAM_DEPTH = 10;
     public static final String ENV_CAUSE = "BUILD_CAUSE";
+    public static final String ENV_ROOT_CAUSE = "ROOT_BUILD_CAUSE";
 
     public Map<String, String> getTriggeredCause(AbstractBuild<?, ?> build) {
-
-        Map<String, String> triggerVars = new HashMap<String, String>();
-        StringBuilder all = new StringBuilder();
         CauseAction causeAction = build.getAction(CauseAction.class);
         List<Cause> buildCauses = causeAction.getCauses();
+        Map<String, String> env = new HashMap<String, String>();
+        List<String> directCauseNames = new ArrayList<String>();
+        Set<String> rootCauseNames = new LinkedHashSet<String>();
         for (Cause cause : buildCauses) {
-            String name = getTriggerName(cause);
+            directCauseNames.add(getTriggerName(cause));
+            insertRootCauseNames(rootCauseNames, cause, 0);
+        }
+        env.putAll(buildCauseEnvironmentVariables(ENV_CAUSE, directCauseNames));
+        env.putAll(buildCauseEnvironmentVariables(ENV_ROOT_CAUSE, rootCauseNames));
+        return env;
+    }
+
+    private static void insertRootCauseNames(Set<String> causeNames, Cause cause, int depth) {
+        if (cause instanceof Cause.UpstreamCause) {
+            if (depth == MAX_UPSTREAM_DEPTH) {
+                causeNames.add("DEEPLYNESTEDCAUSES");
+            } else {
+                Cause.UpstreamCause c = (Cause.UpstreamCause)cause;
+                List<Cause> upstreamCauses = c.getUpstreamCauses();
+                for (Cause upstreamCause : upstreamCauses)
+                    insertRootCauseNames(causeNames, upstreamCause, depth + 1);
+            }
+        } else {
+            causeNames.add(getTriggerName(cause));
+        }
+    }
+
+    private static Map<String, String> buildCauseEnvironmentVariables(String envBase, Collection<String> causeNames) {
+        Map<String, String> triggerVars = new HashMap<String, String>();
+        StringBuilder all = new StringBuilder();
+        for (String name : causeNames) {
             if (!StringUtils.isBlank(name)) {
-                triggerVars.put(ENV_CAUSE + "_" + name, "true");
+                triggerVars.put(envBase + "_" + name, "true");
                 all.append(",");
                 all.append(name);
             }
         }
         // add variable containing all the trigger names
-        triggerVars.put(ENV_CAUSE, all.toString().substring(1));
+        triggerVars.put(envBase, all.toString().substring(1));
         return triggerVars;
     }
-
 
     @SuppressWarnings(value = "deprecation")
     private static String getTriggerName(Cause cause) {


### PR DESCRIPTION
For multi-configuration jobs the BUILD_CAUSE passed in the environment
to build scripts is always UPSTREAMTRIGGER. Introduce ROOT_BUILD_CAUSE
that expands UpstreamCause to the root causes.

Update required jenkins version to 1.482 to get
Cause.UpstreamCause.getUpstreamCauses().
