### PR TITLE
[JENKINS-20334] - envInject leaves in backslash for #, !, =, : 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesLoader.java
@@ -31,32 +31,6 @@ public class PropertiesLoader implements Serializable {
      * @throws EnvInjectException
      * @throws IOException 
      */
-//    public Map<String, String> getVarsFromPropertiesFile(File propertiesFile, Map<String, String> currentEnvVars) throws EnvInjectException {
-//
-//        if (propertiesFile == null) {
-//            throw new NullPointerException("The properties file object must be set.");
-//        }
-//        if (!propertiesFile.exists()) {
-//            throw new IllegalArgumentException("The properties file object must be exist.");
-//        }
-//
-//        Map<String, String> result = new LinkedHashMap<String, String>();
-//
-//        SortedProperties properties = new SortedProperties();
-//        try {
-//            String fileContent = Util.loadFile(propertiesFile);
-//            String fileContentResolved = Util.replaceMacro(fileContent, currentEnvVars);
-//            fileContentResolved = processPath(fileContentResolved);
-//            properties.load(new StringReader(fileContentResolved));
-//        } catch (IOException ioe) {
-//            throw new EnvInjectException("Problem occurs on loading content", ioe);
-//        }
-//        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-//            result.put(processElement(entry.getKey()), processElement(entry.getValue()));
-//        }
-//        return result;
-//    }
-	
 	public Map<String, String> getVarsFromPropertiesFile(File propertiesFile, Map<String, String> currentEnvVars) throws EnvInjectException, IOException {
 		
         if (propertiesFile == null) {

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesLoader.java
@@ -8,7 +8,6 @@ import org.jenkinsci.plugins.envinject.util.SortedProperties;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -56,7 +55,7 @@ public class PropertiesLoader implements Serializable {
         	key = Util.replaceMacro(key, currentEnvVars);
         	value = Util.replaceMacro(value, currentEnvVars);
         	
-        	result.put(processElement(key), processElement(value));
+        	result.put(key, value);
         }
         
         return result;

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesLoader.java
@@ -2,15 +2,20 @@ package org.jenkinsci.plugins.envinject.service;
 
 
 import hudson.Util;
+
 import org.jenkinsci.lib.envinject.EnvInjectException;
 import org.jenkinsci.plugins.envinject.util.SortedProperties;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.io.StringReader;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * @author Gregory Boissinot
@@ -24,30 +29,62 @@ public class PropertiesLoader implements Serializable {
      * @param currentEnvVars the current environment variables to resolve against
      * @return the environment variables
      * @throws EnvInjectException
+     * @throws IOException 
      */
-    public Map<String, String> getVarsFromPropertiesFile(File propertiesFile, Map<String, String> currentEnvVars) throws EnvInjectException {
-
+//    public Map<String, String> getVarsFromPropertiesFile(File propertiesFile, Map<String, String> currentEnvVars) throws EnvInjectException {
+//
+//        if (propertiesFile == null) {
+//            throw new NullPointerException("The properties file object must be set.");
+//        }
+//        if (!propertiesFile.exists()) {
+//            throw new IllegalArgumentException("The properties file object must be exist.");
+//        }
+//
+//        Map<String, String> result = new LinkedHashMap<String, String>();
+//
+//        SortedProperties properties = new SortedProperties();
+//        try {
+//            String fileContent = Util.loadFile(propertiesFile);
+//            String fileContentResolved = Util.replaceMacro(fileContent, currentEnvVars);
+//            fileContentResolved = processPath(fileContentResolved);
+//            properties.load(new StringReader(fileContentResolved));
+//        } catch (IOException ioe) {
+//            throw new EnvInjectException("Problem occurs on loading content", ioe);
+//        }
+//        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+//            result.put(processElement(entry.getKey()), processElement(entry.getValue()));
+//        }
+//        return result;
+//    }
+	
+	public Map<String, String> getVarsFromPropertiesFile(File propertiesFile, Map<String, String> currentEnvVars) throws EnvInjectException, IOException {
+		
         if (propertiesFile == null) {
             throw new NullPointerException("The properties file object must be set.");
         }
         if (!propertiesFile.exists()) {
             throw new IllegalArgumentException("The properties file object must be exist.");
         }
-
+        
+        // Read file using Java properties
+        InputStream propertiesFileStream = new FileInputStream(propertiesFile);
+        Properties properties = new Properties();
+        properties.load(propertiesFileStream);
+        
+        // Map to hold the properties with resolved environment variables
         Map<String, String> result = new LinkedHashMap<String, String>();
-
-        SortedProperties properties = new SortedProperties();
-        try {
-            String fileContent = Util.loadFile(propertiesFile);
-            String fileContentResolved = Util.replaceMacro(fileContent, currentEnvVars);
-            fileContentResolved = processPath(fileContentResolved);
-            properties.load(new StringReader(fileContentResolved));
-        } catch (IOException ioe) {
-            throw new EnvInjectException("Problem occurs on loading content", ioe);
+        
+        // iterate over properties
+        for (String key : properties.stringPropertyNames()) {
+        	String value = properties.getProperty(key);
+        	
+        	// resolve environment variables for both keys and values
+        	key = Util.replaceMacro(key, currentEnvVars);
+        	value = Util.replaceMacro(value, currentEnvVars);
+        	
+        	result.put(processElement(key), processElement(value));
         }
-        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-            result.put(processElement(entry.getKey()), processElement(entry.getValue()));
-        }
+        
         return result;
     }
 

--- a/src/test/java/org/jenkinsci/plugins/envinject/sevice/PropertiesLoaderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/sevice/PropertiesLoaderTest.java
@@ -182,8 +182,8 @@ public class PropertiesLoaderTest {
 			new HashMap<String, String>());
 
 	assertNotNull(gatherVars);
-	assertEquals(3, gatherVars.size());
-	assertEquals(keys[0], gatherVars.get("KEY1"));
+	assertEquals(4, gatherVars.size());
+	assertEquals(keys[0], gatherVars.get("KEY1 "));
 	assertEquals(keys[1], gatherVars.get("KEY2"));
 	assertEquals(keys[2], gatherVars.get("KEY3"));
 	assertEquals(keys[3], gatherVars.get("KEY4"));

--- a/src/test/java/org/jenkinsci/plugins/envinject/sevice/PropertiesLoaderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/sevice/PropertiesLoaderTest.java
@@ -1,14 +1,17 @@
 package org.jenkinsci.plugins.envinject.sevice;
 
-import org.apache.commons.io.FileUtils;
-import org.jenkinsci.plugins.envinject.service.PropertiesLoader;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
-import static org.junit.Assert.*;
+import org.jenkinsci.plugins.envinject.service.PropertiesLoader;
+import org.junit.Test;
 
 /**
  * @author Gregory Boissinot
@@ -17,18 +20,31 @@ public class PropertiesLoaderTest {
 
     PropertiesLoader propertiesLoader = new PropertiesLoader();
 
+    
     //-- File
 
+    /**
+     * Test null properties File.
+     * @throws Exception for null File.
+     */
     @Test(expected = NullPointerException.class)
     public void nullFile() throws Exception {
         propertiesLoader.getVarsFromPropertiesFile(null, new HashMap<String, String>());
     }
 
+    /**
+     * Test new file with non-existing path.
+     * @throws Exception for non-existing path.
+     */
     @Test(expected = IllegalArgumentException.class)
     public void notExistFile() throws Exception {
         propertiesLoader.getVarsFromPropertiesFile(new File("not exist"), new HashMap<String, String>());
     }
 
+    /**
+     * Test file with no content.
+     * @throws Exception on file creation.
+     */
     @Test
     public void emptyFile() throws Exception {
         File emptyFile = File.createTempFile("test", "test");
@@ -40,11 +56,19 @@ public class PropertiesLoaderTest {
 
     //-- Content
 
+    /**
+     * Test null content in the interface field.
+     * @throws Exception for null content.
+     */
     @Test(expected = NullPointerException.class)
     public void nullContent() throws Exception {
         propertiesLoader.getVarsFromPropertiesContent(null, new HashMap<String, String>());
     }
 
+    /**
+     * Test empty content in the interface field.
+     * @throws Exception for invalid content.
+     */
     @Test(expected = IllegalArgumentException.class)
     public void emptyContent() throws Exception {
         Map<String, String> currentEnvVars = new HashMap<String, String>();
@@ -55,37 +79,77 @@ public class PropertiesLoaderTest {
 
     //--Both
 
+    /**
+     * Test properties file with a single key/value pair.
+     * @throws Exception on file read/write
+     */
     @Test
     public void fileWithOneElement() throws Exception {
-        checkWithOneElement(true);
-    }
+	// Create properties file containing backslash-escaped newlines
+	Properties prop = new Properties();
+	prop.setProperty("SOMEKEY", "SOMEVALUE");
 
-    @Test
-    public void contentWithOneElement() throws Exception {
-        checkWithOneElement(false);
-    }
-
-    private void checkWithOneElement(boolean fromFile) throws Exception {
-        String content = "SOMEKEY=SOMEVALUE";
-        Map<String, String> gatherVars = gatherEnvVars(fromFile, content, new HashMap<String, String>());
+	File propFile = File.createTempFile("test", "test");
+	OutputStream output = new FileOutputStream(propFile);
+	prop.store(output, null);
+	
+	Map<String, String> gatherVars = propertiesLoader.getVarsFromPropertiesFile(propFile, new HashMap<String, String>());
         assertNotNull(gatherVars);
         assertEquals(1, gatherVars.size());
         assertEquals("SOMEVALUE", gatherVars.get("SOMEKEY"));
     }
 
+    /**
+     * Test content with a single key/value pair.
+     * @throws Exception reading content.
+     */
+    @Test
+    public void contentWithOneElement() throws Exception {
+	String content = "SOMEKEY=SOMEVALUE";
+        Map<String, String> gatherVars = propertiesLoader.getVarsFromPropertiesContent(content, new HashMap<String, String>());
+        assertNotNull(gatherVars);
+        assertEquals(1, gatherVars.size());
+        assertEquals("SOMEVALUE", gatherVars.get("SOMEKEY"));
+    }
+
+    /**
+     * Test properties file with three key/value pairs.
+     * @throws Exception on file read/write
+     */
     @Test
     public void fileWithThreeElements() throws Exception {
-        checkWithThreeElements(true);
+	// Create properties file containing backslash-escaped newlines
+	String keys[] = { "VALUE1", "VALUE2", "VALUE3" };
+
+	Properties prop = new Properties();
+	prop.setProperty("KEY1", keys[0]);
+	prop.setProperty("KEY2", keys[1]);
+	prop.setProperty("KEY3", keys[2]);
+
+	File propFile = File.createTempFile("test", "test");
+	OutputStream output = new FileOutputStream(propFile);
+	prop.store(output, null);
+
+	// Read properties file using envInject file loader
+	Map<String, String> gatherVars = propertiesLoader
+		.getVarsFromPropertiesFile(propFile,
+			new HashMap<String, String>());
+	
+	assertNotNull(gatherVars);
+        assertEquals(3, gatherVars.size());
+        assertEquals(keys[0], gatherVars.get("KEY1"));
+        assertEquals(keys[1], gatherVars.get("KEY2"));
+        assertEquals(keys[2], gatherVars.get("KEY3"));
     }
 
+    /**
+     * Test content with three key/value pairs.
+     * @throws Exception reading content.
+     */
     @Test
     public void contentWithThreeElements() throws Exception {
-        checkWithThreeElements(false);
-    }
-
-    private void checkWithThreeElements(boolean fromFile) throws Exception {
-        String content = "KEY1=VALUE1\nKEY2=VALUE2\nKEY3=VALUE3";
-        Map<String, String> gatherVars = gatherEnvVars(fromFile, content, new HashMap<String, String>());
+	String content = "KEY1=VALUE1\nKEY2=VALUE2\nKEY3=VALUE3";
+        Map<String, String> gatherVars = propertiesLoader.getVarsFromPropertiesContent(content, new HashMap<String, String>());
         assertNotNull(gatherVars);
         assertEquals(3, gatherVars.size());
         assertEquals("VALUE1", gatherVars.get("KEY1"));
@@ -93,19 +157,46 @@ public class PropertiesLoaderTest {
         assertEquals("VALUE3", gatherVars.get("KEY3"));
     }
 
+    /**
+     * Test properties file where keys and/or values have spaces.
+     * @throws Exception on file read/write
+     */
     @Test
     public void fileWithSpaceInElements() throws Exception {
-        checkWithSpaceInElements(true);
+	// Create properties file containing backslash-escaped newlines
+	String keys[] = { "VALUE1", "VALUE2", "VALUE3 ", " VALUE4 " };
+
+	Properties prop = new Properties();
+	prop.setProperty("KEY1 ", keys[0]);
+	prop.setProperty("KEY2", keys[1]);
+	prop.setProperty("KEY3", keys[2]);
+	prop.setProperty("KEY4", keys[3]);
+
+	File propFile = File.createTempFile("test", "test");
+	OutputStream output = new FileOutputStream(propFile);
+	prop.store(output, null);
+
+	// Read properties file using envInject file loader
+	Map<String, String> gatherVars = propertiesLoader
+		.getVarsFromPropertiesFile(propFile,
+			new HashMap<String, String>());
+
+	assertNotNull(gatherVars);
+	assertEquals(3, gatherVars.size());
+	assertEquals(keys[0], gatherVars.get("KEY1"));
+	assertEquals(keys[1], gatherVars.get("KEY2"));
+	assertEquals(keys[2], gatherVars.get("KEY3"));
+	assertEquals(keys[3], gatherVars.get("KEY4"));
     }
 
+    /**
+     * Test content where keys and/or values have spaces.
+     * @throws Exception reading content.
+     */
     @Test
     public void contentWithSpaceInElements() throws Exception {
-        checkWithSpaceInElements(false);
-    }
-
-    private void checkWithSpaceInElements(boolean fromFile) throws Exception {
-        String content = "KEY1 =VALUE1\nKEY2=VALUE2\nKEY3=VALUE3 ";
-        Map<String, String> gatherVars = gatherEnvVars(fromFile, content, new HashMap<String, String>());
+	String content = "KEY1 =VALUE1\nKEY2=VALUE2\nKEY3=VALUE3 ";
+        Map<String, String> gatherVars = propertiesLoader.getVarsFromPropertiesContent(content, new HashMap<String, String>());
         assertNotNull(gatherVars);
         assertEquals(3, gatherVars.size());
         assertEquals("VALUE1", gatherVars.get("KEY1"));
@@ -113,20 +204,47 @@ public class PropertiesLoaderTest {
         assertEquals("VALUE3", gatherVars.get("KEY3"));
     }
 
+    /**
+     * Test properties file with newlines in the values.
+     * @throws Exception on file read/write
+     */
     @Test
     public void fileWithNewlineInValues() throws Exception {
-        checkWithNewlineInValues(true);
+	// Create properties file containing backslash-escaped newlines
+	String keys[] = { "line1\nline2", "line1 \nline2", "line1\n\nline3" };
+
+	Properties prop = new Properties();
+	prop.setProperty("KEY1", keys[0]);
+	prop.setProperty("KEY2", keys[1]);
+	prop.setProperty("KEY3", keys[2]);
+
+	File propFile = File.createTempFile("test", "test");
+	OutputStream output = new FileOutputStream(propFile);
+	prop.store(output, null);
+
+	// Read properties file using envInject file loader
+	Map<String, String> gatherVars = propertiesLoader
+		.getVarsFromPropertiesFile(propFile,
+			new HashMap<String, String>());
+	assertNotNull(gatherVars);
+	assertEquals(3, gatherVars.size());
+
+	// Values should be trimmed at start & end, otherwise whitespace &
+	// newlines should be kept
+	assertEquals(keys[0], gatherVars.get("KEY1"));
+	assertEquals(keys[1], gatherVars.get("KEY2"));
+	assertEquals(keys[2], gatherVars.get("KEY3"));
     }
 
+    /**
+     * Test content with newlines in the values.
+     * @throws Exception reading content.
+     */
     @Test
     public void contentWithNewlineInValues() throws Exception {
-        checkWithNewlineInValues(false);
-    }
-
-    private void checkWithNewlineInValues(boolean fromFile) throws Exception {
-        // Create properties file containing backslash-escaped newlines
+	// Create properties file containing backslash-escaped newlines
         String content = "KEY1=line1\\\nline2\nKEY2= line1 \\\n line2 \nKEY3=line1\\\n\\\nline3";
-        Map<String, String> gatherVars = gatherEnvVars(fromFile, content, new HashMap<String, String>());
+        Map<String, String> gatherVars = propertiesLoader.getVarsFromPropertiesContent(content, new HashMap<String, String>());
         assertNotNull(gatherVars);
         assertEquals(3, gatherVars.size());
 
@@ -136,38 +254,57 @@ public class PropertiesLoaderTest {
         assertEquals("line1\n\nline3", gatherVars.get("KEY3"));
     }
 
+    /**
+     * Test properties file where keys and/or values are environment variables.
+     * @throws Exception on file read/write.
+     */
     @Test
     public void fileWithVarsToResolve() throws Exception {
-        checkWithVarsToResolve(true);
-    }
-
-    @Test
-    public void contentWithVarsToResolve() throws Exception {
-        checkWithVarsToResolve(false);
-    }
-
-    private void checkWithVarsToResolve(boolean fromFile) throws Exception {
-        String content = "KEY1 =${VAR1_TO_RESOLVE}\nKEY2=VALUE2\nKEY3=${VAR3_TO_RESOLVE}\\otherContent";
-        Map<String, String> currentEnvVars = new HashMap<String, String>();
+        // Preset environment variables
+	Map<String, String> currentEnvVars = new HashMap<String, String>();
         currentEnvVars.put("VAR1_TO_RESOLVE", "NEW_VALUE1");
         currentEnvVars.put("VAR3_TO_RESOLVE", "NEW_VALUE3");
+        currentEnvVars.put("KEY4_TO_RESOLVE", "NEW_KEY4");
+        
+	// Create properties file containing backslash-escaped newlines
+	Properties prop = new Properties();
+	prop.setProperty("KEY1", "${VAR1_TO_RESOLVE}");
+	prop.setProperty("KEY2", "VALUE2");
+	prop.setProperty("KEY3", "${VAR3_TO_RESOLVE}\\otherContent");
+	prop.setProperty("${KEY4_TO_RESOLVE}", "VALUE4");
 
-        Map<String, String> gatherVars = gatherEnvVars(fromFile, content, currentEnvVars);
+	File propFile = File.createTempFile("test", "test");
+	OutputStream output = new FileOutputStream(propFile);
+	prop.store(output, null);
+	
+	Map<String, String> gatherVars = propertiesLoader.getVarsFromPropertiesFile(propFile, currentEnvVars);
         assertNotNull(gatherVars);
-        assertEquals(3, gatherVars.size());
+        assertEquals(4, gatherVars.size());
         assertEquals("NEW_VALUE1", gatherVars.get("KEY1"));
         assertEquals("VALUE2", gatherVars.get("KEY2"));
         assertEquals("NEW_VALUE3\\otherContent", gatherVars.get("KEY3"));
+        assertEquals("VALUE4", gatherVars.get("NEW_KEY4"));
     }
 
-    private Map<String, String> gatherEnvVars(boolean fromFile, String content2Load, Map<String, String> currentEnvVars) throws Exception {
-        File propFile = File.createTempFile("test", "test");
-        FileUtils.writeStringToFile(propFile, content2Load);
-        if (fromFile) {
-            return propertiesLoader.getVarsFromPropertiesFile(propFile, currentEnvVars);
-        } else {
-            return propertiesLoader.getVarsFromPropertiesContent(content2Load, currentEnvVars);
-        }
+    /**
+     * Test content where keys and/or values are environment variables.
+     * @throws Exception reading content.
+     */
+    @Test
+    public void contentWithVarsToResolve() throws Exception {
+	String content = "KEY1 =${VAR1_TO_RESOLVE}\nKEY2=VALUE2\nKEY3=${VAR3_TO_RESOLVE}\\otherContent\n${KEY4_TO_RESOLVE}=VALUE4";
+        Map<String, String> currentEnvVars = new HashMap<String, String>();
+        currentEnvVars.put("VAR1_TO_RESOLVE", "NEW_VALUE1");
+        currentEnvVars.put("VAR3_TO_RESOLVE", "NEW_VALUE3");
+        currentEnvVars.put("KEY4_TO_RESOLVE", "NEW_KEY4");
+
+        Map<String, String> gatherVars = propertiesLoader.getVarsFromPropertiesContent(content, currentEnvVars);
+        assertNotNull(gatherVars);
+        assertEquals(4, gatherVars.size());
+        assertEquals("NEW_VALUE1", gatherVars.get("KEY1"));
+        assertEquals("VALUE2", gatherVars.get("KEY2"));
+        assertEquals("NEW_VALUE3\\otherContent", gatherVars.get("KEY3"));
+        assertEquals("VALUE4", gatherVars.get("NEW_KEY4"));
     }
 
 }


### PR DESCRIPTION
The main motivation for this fix was the issue [JENKINS-20334](https://issues.jenkins-ci.org/browse/JENKINS-20334), although it could solve other issues which are unknown to me at the moment.

Since **EnvInject** plugin is expected to read from a *.properties* file, it should use the very same convention as defined in *java.util.Properties*:
> *[...] Characters that cannot be directly represented in this encoding can be written using Unicode escapes as defined in [section 3.3 of The Java™ Language Specification](https://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.3) [...]*

The *load()* and *store()* methods provided by the *Properties* class natively handles these twists during serialization/deserialization. So, why not use it directly instead of *hudson.Util.loadFile(…)* followed by manual “unescaping” of the properties (using *processPath(…)*)?
At this point, the local/remote nature of the file has already been resolved.

The implementation in this Pull Request was tested with several properties and special characters. It was also tested in a master/slave configuration (slaves on virtual machine).