### PR TITLE
[WiP] - Replace periods in property names with underscores.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/util/SortedProperties.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/util/SortedProperties.java
@@ -191,7 +191,7 @@ public class SortedProperties extends LinkedHashMap<Object, Object> {
                 }
                 valueStart++;
             }
-            String key = loadConvert(lr.lineBuf, 0, keyLen, convtBuf);
+            String key = loadConvert(lr.lineBuf, 0, keyLen, convtBuf).replace('.', '_');
             String value = loadConvert(lr.lineBuf, valueStart, limit - valueStart, convtBuf);
             put(key, value);
         }


### PR DESCRIPTION
Addresses JENKINS-13904.  Spring automatically maps periods to underscores and back and most properties in Java files are dotted.