### PR TITLE
JENKINS-28188 StringIndexOutOfBoundsException when no root cause

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/service/BuildCauseRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/BuildCauseRetriever.java
@@ -59,20 +59,15 @@ public class BuildCauseRetriever {
 
     private static Map<String, String> buildCauseEnvironmentVariables(String envBase, Collection<String> causeNames) {
         Map<String, String> triggerVars = new HashMap<String, String>();
-        StringBuilder all = new StringBuilder();
-        int count = 0;
+        List<String> all = new ArrayList<String>();
         for (String name : causeNames) {
             if (!StringUtils.isBlank(name)) {
                 triggerVars.put(envBase + "_" + name, "true");
-                if (count > 0) {
-                    all.append(",");
-                }
-                all.append(name);
-                count++;
+                all.add(name);
             }
         }
         // add variable containing all the trigger names
-        triggerVars.put(envBase, all.toString());
+        triggerVars.put(envBase, StringUtils.join(all, ","));
         return triggerVars;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/BuildCauseRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/BuildCauseRetriever.java
@@ -60,15 +60,19 @@ public class BuildCauseRetriever {
     private static Map<String, String> buildCauseEnvironmentVariables(String envBase, Collection<String> causeNames) {
         Map<String, String> triggerVars = new HashMap<String, String>();
         StringBuilder all = new StringBuilder();
+        int count = 0;
         for (String name : causeNames) {
             if (!StringUtils.isBlank(name)) {
                 triggerVars.put(envBase + "_" + name, "true");
-                all.append(",");
+                if (count > 0) {
+                    all.append(",");
+                }
                 all.append(name);
+                count++;
             }
         }
         // add variable containing all the trigger names
-        triggerVars.put(envBase, all.toString().substring(1));
+        triggerVars.put(envBase, all.toString());
         return triggerVars;
     }
 


### PR DESCRIPTION
When a build has no root cause (possible when firing the job programmatically), the code at `org.jenkinsci.plugins.envinject.service.BuildCauseRetriever#buildCauseEnvironmentVariables` produces a `StringIndexOutOfBoundsException` because the substring method is applied to an empty string.

The fix I propose is very basic and could be simplified using Guava - but I didn't date to use it in this plugin.