### PR TITLE
[FIXED JENKINS-28409] - Properly close parent streams in EnvInjectPasswordsOutputStream

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPasswordWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPasswordWrapper.java
@@ -198,6 +198,12 @@ public class EnvInjectPasswordWrapper extends BuildWrapper {
             }
             logger.write(line.getBytes());
         }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            logger.close();
+        }       
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectPasswordTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectPasswordTest.java
@@ -1,7 +1,14 @@
 package org.jenkinsci.plugins.envinject;
 
+import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.*;
+import hudson.tasks.BuildWrapper;
+import hudson.tasks.BuildWrapperDescriptor;
 import hudson.util.Secret;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import junit.framework.Assert;
 import org.jenkinsci.lib.envinject.EnvInjectAction;
 import org.jvnet.hudson.test.HudsonTestCase;
@@ -9,6 +16,9 @@ import org.jvnet.hudson.test.HudsonTestCase;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
+import org.jvnet.hudson.test.Bug;
+import org.jvnet.hudson.test.TestExtension;
 
 /**
  * @author Gregory Boissinot
@@ -53,10 +63,96 @@ public class EnvInjectPasswordTest extends HudsonTestCase {
         checkEnvInjectResult(build);
     }
 
+    @Bug(28409)
+    public void testFileHandlesLeak() throws Exception {
+        final EnvInjectPasswordWrapper passwordWrapper = new EnvInjectPasswordWrapper();
+        passwordWrapper.setPasswordEntries(new EnvInjectPasswordEntry[]{
+                new EnvInjectPasswordEntry(PWD_KEY, PWD_VALUE)
+        });
+        final FileLeakBuildWrapper fileLeakDetector = new FileLeakBuildWrapper();
+
+        project.getBuildWrappersList().add(fileLeakDetector);
+        project.getBuildWrappersList().add(passwordWrapper);
+        
+        @SuppressWarnings("deprecation")  
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        assertBuildStatusSuccess(build);
+        
+        Assert.assertTrue("Nested output stream has not been closed", fileLeakDetector.getLastOutputStream().isClosed());    
+    } 
+    
     private void checkEnvInjectResult(FreeStyleBuild build) {
         EnvInjectAction action = build.getAction(EnvInjectAction.class);
         Map<String, String> envVars = action.getEnvMap();
         //The value must be encrypted in the envVars
         Assert.assertEquals(Secret.fromString(PWD_VALUE).getEncryptedValue(), envVars.get(PWD_KEY));
+    }    
+    
+    /**
+     * A wrapper for an {@link OutputStream}, which raises the flag when a
+     * stream gets closed externally.
+     * @since TODO
+     */
+    public static class FileLeakDetectorStream extends FilterOutputStream {
+        
+        private boolean closed;
+
+        public FileLeakDetectorStream(OutputStream out) {
+            super(out);
+            this.closed = false;
+        }
+
+        public boolean isClosed() {
+            return closed;
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            closed = true;
+        }  
+    }
+    
+    /**
+     * A class, which decorates loggers by {@link FileLeakDetectorStream}.
+     * @since TODO
+     */
+    public static class FileLeakBuildWrapper extends BuildWrapper {
+
+        private FileLeakDetectorStream lastOutputStream = null;
+
+        public FileLeakDetectorStream getLastOutputStream() {
+            return lastOutputStream;
+        }
+            
+        @Override
+        public OutputStream decorateLogger(AbstractBuild build, OutputStream logger) throws IOException, InterruptedException, Run.RunnerAbortedException {
+            lastOutputStream = new FileLeakDetectorStream(logger);
+            return lastOutputStream;
+        }  
+
+        @Override
+        public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
+            return new Environment() {
+                @Override
+                public void buildEnvVars(Map<String, String> env) {
+                    //Do nothing
+                }             
+            };
+        }
+         
+        @TestExtension
+        public static class DescriptorImpl extends BuildWrapperDescriptor {
+            
+            @Override
+            public String getDisplayName() {
+                return "N/A";
+            }
+
+            @Override
+            public boolean isApplicable(AbstractProject<?, ?> item) {
+                return true;
+            }      
+        }
     }
 }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-28409

@reviewbybees