### PR TITLE
[FIXED JENKINS-29667] Text description in plugin manager shouldn't be in bold

### DIFF
--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,6 +1,3 @@
 <div>
-    <p>
-        This plugin makes it possible to set an environment for the builds.
-        <br/>
-    </p>
+    This plugin makes it possible to set an environment for the builds.
 </div>


### PR DESCRIPTION

Signed-off-by: Anders Hammar <anders@hammar.net>