### PR TITLE
[JENKINS-27665] - Bump envinject-lib version dependency to 1.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
-        <envinject.lib.version>1.21</envinject.lib.version>
+        <envinject.lib.version>1.22</envinject.lib.version>
         <ivy.plugin.version>1.21</ivy.plugin.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
It's a follow-up to https://github.com/jenkinsci/envinject-lib/pull/4.
The plugin has been already patched in https://github.com/jenkinsci/envinject-plugin/commit/b78c45cc336b2875ca7e4da4c25c95c2235a4e1c, but it's better to use a new library to push it to other potential use cases. 

@reviewbybees @aheritier 