### PR TITLE
Updated tests to use JenkinsRule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/envinject-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/envinject-plugin.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <build>
         <plugins>
@@ -62,10 +62,6 @@
     </build>
     
     <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>maven-plugin</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.lib</groupId>
@@ -93,6 +89,7 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <repositories>

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectJobProperty.java
@@ -6,7 +6,6 @@ import hudson.model.Descriptor;
 import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
-import hudson.model.ReconfigurableDescribable;
 import jenkins.model.Jenkins;
 import net.sf.json.JSON;
 import net.sf.json.JSONException;
@@ -78,7 +77,7 @@ public class EnvInjectJobProperty<T extends Job<?, ?>> extends JobProperty<T> {
         DescriptorExtensionList<EnvInjectJobPropertyContributor, EnvInjectJobPropertyContributorDescriptor>
                 descriptors = EnvInjectJobPropertyContributor.all();
 
-        //If the config are loaded with success (this step) and the descriptors size doesn't have change
+        // If the config are loaded with success (this step) and the descriptors size doesn't have change
         // we considerate, they are the same, therefore we retrieve instances
         if (contributors != null && contributors.length == descriptors.size()) {
             return contributors;

--- a/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectEnvVarsEmpty.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectEnvVarsEmpty.java
@@ -3,21 +3,28 @@ package org.jenkinsci.plugins.envinject;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
-import junit.framework.Assert;
 
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Gregory Boissinot
  */
-public class EnvInjectEnvVarsEmpty extends HudsonTestCase {
+public class EnvInjectEnvVarsEmpty {
 
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
 
+    @Test
     public void testEmptyVars1() throws Exception {
 
-        FreeStyleProject project = createFreeStyleProject();
+        FreeStyleProject project = jenkins.createFreeStyleProject();
         StringBuffer propertiesContent = new StringBuffer("EMPTYVAR1=\n");
         propertiesContent.append("VAR2=VAL2");
         EnvInjectJobPropertyInfo jobPropertyInfo = new EnvInjectJobPropertyInfo(null, propertiesContent.toString(), null, null, null, false);
@@ -27,21 +34,21 @@ public class EnvInjectEnvVarsEmpty extends HudsonTestCase {
         project.addProperty(envInjectJobProperty);
 
         FreeStyleBuild build = project.scheduleBuild2(0).get();
-        Assert.assertEquals(Result.SUCCESS, build.getResult());
+        assertEquals(Result.SUCCESS, build.getResult());
 
 
         org.jenkinsci.lib.envinject.EnvInjectAction envInjectAction = build.getAction(org.jenkinsci.lib.envinject.EnvInjectAction.class);
-        Assert.assertNotNull(envInjectAction);
+        assertNotNull(envInjectAction);
         Map<String, String> envVars = envInjectAction.getEnvMap();
-        Assert.assertNotNull(envVars);
+        assertNotNull(envVars);
 
 
         String resultValEnvVar1 = envVars.get("EMPTYVAR1");
         String resultValEnvVar2 = envVars.get("VAR2");
-        Assert.assertNotNull(resultValEnvVar1);
-        Assert.assertNotNull(resultValEnvVar2);
+        assertNotNull(resultValEnvVar1);
+        assertNotNull(resultValEnvVar2);
 
-        Assert.assertEquals(0, resultValEnvVar1.length());
-        Assert.assertEquals("VAL2", resultValEnvVar2);
+        assertEquals(0, resultValEnvVar1.length());
+        assertEquals("VAL2", resultValEnvVar2);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectEvaluatedGroovyScript.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectEvaluatedGroovyScript.java
@@ -1,21 +1,30 @@
 package org.jenkinsci.plugins.envinject;
 
 import hudson.model.*;
-import junit.framework.Assert;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+
 /**
  * @author Gregory Boissinot
  */
-public class EnvInjectEvaluatedGroovyScript extends HudsonTestCase {
+public class EnvInjectEvaluatedGroovyScript {
 
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
     public void testMapGroovyScript() throws Exception {
 
-        FreeStyleProject project = createFreeStyleProject("jobTest");
+        FreeStyleProject project = jenkins.createFreeStyleProject("jobTest");
 
         StringBuffer groovyScriptContent = new StringBuffer();
         groovyScriptContent.append(
@@ -48,22 +57,22 @@ public class EnvInjectEvaluatedGroovyScript extends HudsonTestCase {
 
         @SuppressWarnings("deprecation")
         FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserCause(), parametersAction).get();
-        Assert.assertEquals(Result.SUCCESS, build.getResult());
+        assertEquals(Result.SUCCESS, build.getResult());
 
         org.jenkinsci.lib.envinject.EnvInjectAction envInjectAction = build.getAction(org.jenkinsci.lib.envinject.EnvInjectAction.class);
-        Assert.assertNotNull(envInjectAction);
+        assertNotNull(envInjectAction);
         Map<String, String> envVars = envInjectAction.getEnvMap();
-        Assert.assertNotNull(envVars);
+        assertNotNull(envVars);
 
         String resultValEnvVar = envVars.get("COMPUTE_VAR");
-        Assert.assertNotNull(resultValEnvVar);
-        Assert.assertEquals("string", resultValEnvVar);
+        assertNotNull(resultValEnvVar);
+        assertEquals("string", resultValEnvVar);
     }
 
-
+    @Test
     public void testBuildInVars() throws Exception {
 
-        FreeStyleProject project = createFreeStyleProject("jobTest");
+        FreeStyleProject project = jenkins.createFreeStyleProject("jobTest");
 
         StringBuffer groovyScriptContent = new StringBuffer();
         groovyScriptContent.append(
@@ -87,17 +96,17 @@ public class EnvInjectEvaluatedGroovyScript extends HudsonTestCase {
 
         @SuppressWarnings("deprecation")
         FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserCause(), parametersAction).get();
-        Assert.assertEquals(Result.SUCCESS, build.getResult());
+        assertEquals(Result.SUCCESS, build.getResult());
 
         org.jenkinsci.lib.envinject.EnvInjectAction envInjectAction = build.getAction(org.jenkinsci.lib.envinject.EnvInjectAction.class);
-        Assert.assertNotNull(envInjectAction);
+        assertNotNull(envInjectAction);
         Map<String, String> envVars = envInjectAction.getEnvMap();
-        Assert.assertNotNull(envVars);
+        assertNotNull(envVars);
 
         String resultValEnvVar1 = envVars.get("COMPUTE_VAR1");
         String resultValEnvVar2 = envVars.get("COMPUTE_VAR2");
-        Assert.assertNotNull(resultValEnvVar1);
-        Assert.assertNotNull(resultValEnvVar2);
-        Assert.assertEquals(resultValEnvVar2, resultValEnvVar1);
+        assertNotNull(resultValEnvVar1);
+        assertNotNull(resultValEnvVar2);
+        assertEquals(resultValEnvVar2, resultValEnvVar1);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectPasswordMatrixProjectTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectPasswordMatrixProjectTest.java
@@ -4,29 +4,28 @@ import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixProject;
 import hudson.model.Result;
 import hudson.util.Secret;
-import junit.framework.Assert;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Gregory Boissinot
  */
-public class EnvInjectPasswordMatrixProjectTest extends HudsonTestCase {
+public class EnvInjectPasswordMatrixProjectTest {
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
 
     private static final String PWD_KEY = "PASS_KEY";
     private static final String PWD_VALUE = "PASS_VALUE";
 
-    private MatrixProject project;
-
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        project = createMatrixProject();
-    }
-
+    @Test
     public void testEnvInjectPasswordWrapper() throws Exception {
-
+        MatrixProject project = jenkins.createMatrixProject();
         EnvInjectPasswordWrapper passwordWrapper = new EnvInjectPasswordWrapper();
         passwordWrapper.setPasswordEntries(new EnvInjectPasswordEntry[]{
                 new EnvInjectPasswordEntry(PWD_KEY, PWD_VALUE)
@@ -34,13 +33,11 @@ public class EnvInjectPasswordMatrixProjectTest extends HudsonTestCase {
 
         project.getBuildWrappersList().add(passwordWrapper);
         MatrixBuild matrixBuild = project.scheduleBuild2(0).get();
-        Assert.assertEquals(Result.SUCCESS, matrixBuild.getResult());
+        assertEquals(Result.SUCCESS, matrixBuild.getResult());
 
         org.jenkinsci.lib.envinject.EnvInjectAction action = matrixBuild.getAction(org.jenkinsci.lib.envinject.EnvInjectAction.class);
         Map<String, String> envVars = action.getEnvMap();
         //The value must be encrypted in the envVars
-        Assert.assertEquals(Secret.fromString(PWD_VALUE).getEncryptedValue(), envVars.get(PWD_KEY));
-
+        assertEquals(Secret.fromString(PWD_VALUE).getEncryptedValue(), envVars.get(PWD_KEY));
     }
-
 }


### PR DESCRIPTION
Update tests to avoid the deprecated HudsonTestCase:

- [x] EnvInjectEnvVarsEmpty
- [x] EnvInjectJobProperty
- [x] EnvInjectPasswordMatrixProjectTest
- [x] GlobalPropertiesTest
- [x] EnvInjectPasswordTest

@gboissinot, as maintainer of this plugin, I hope you consider useful these changes.