### PR TITLE
[JENKINS-29867] - Permissions engine + global option for disabling the Injected vars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
-        <envinject.lib.version>1.22</envinject.lib.version>
+        <envinject.lib.version>1.23</envinject.lib.version>
         <ivy.plugin.version>1.21</ivy.plugin.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectAction.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectAction.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 /**
  * @author Gregory Boissinot
+ * @deprecated Replaced by {@link EnvInjectPluginAction}.
  */
 @Deprecated
 public class EnvInjectAction implements Action, StaplerProxy {
@@ -45,20 +46,38 @@ public class EnvInjectAction implements Action, StaplerProxy {
         return UnmodifiableMap.decorate(envMap);
     }
 
+    @Override
     public String getIconFileName() {
+        if (!EnvInjectPlugin.canViewInjectedVars(build)) {
+            return null;
+        }
         return "document-properties.gif";
     }
 
+    @Override
     public String getDisplayName() {
         return "Environment Variables";
     }
 
+    @Override
     public String getUrlName() {
+        if (!EnvInjectPlugin.canViewInjectedVars(build)) {
+            return null;
+        }
         return URL_NAME;
     }
 
+    protected AbstractBuild getBuild() {
+        return build;
+    }
+    
+    @Override
     public Object getTarget() {
         final Set sensitiveVariables = build.getSensitiveBuildVariables();
+        if (!EnvInjectPlugin.canViewInjectedVars(build)) {
+            return EnvInjectVarList.HIDDEN;
+        }
+        
         return new EnvInjectVarList(Maps.transformEntries(envMap,
                 new Maps.EntryTransformer<String, String, String>() {
                     public String transformEntry(String key, String value) {

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPlugin.java
@@ -1,0 +1,113 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.envinject;
+
+import hudson.Plugin;
+import hudson.model.Run;
+import hudson.security.Permission;
+import hudson.security.PermissionGroup;
+import hudson.security.PermissionScope;
+import java.util.logging.Logger;
+import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.export.ExportedBean;
+
+/**
+ * Stores permissions for EnvInject plugin.
+ * @author Oleg Nenashev
+ * @since 1.92
+ */
+@ExportedBean
+public class EnvInjectPlugin extends Plugin {
+
+    private final static Logger LOGGER = Logger.getLogger(EnvInjectPlugin.class.getName());
+
+    public static final PermissionGroup PERMISSIONS = new PermissionGroup(EnvInjectPlugin.class, Messages._envinject_permissions_title());
+
+    /**
+     * Allows to view injected variables.
+     * Even Jenkins admins may have no such permission in particular installations.
+     */
+    public static final Permission VIEW_INJECTED_VARS = new Permission(PERMISSIONS, "ViewVars", Messages._envinject_permissions_viewVars_description(), null, PermissionScope.RUN);
+     
+    /**
+     * Retrieves the plugin instance.
+     * @return {@link EnvInjectPlugin}
+     * @throws IllegalStateException the plugin has not been loaded yet
+     */
+    public static @Nonnull EnvInjectPlugin getInstance() {
+        Jenkins j = Jenkins.getInstance();
+        EnvInjectPlugin plugin = j != null ? j.getPlugin(EnvInjectPlugin.class) : null;
+        if (plugin == null) { // Fail horribly
+            // TODO: throw a graceful error
+            throw new IllegalStateException("Cannot get the plugin's instance. Jenkins or the plugin have not been initialized yet");
+        }
+        return plugin;
+    }
+    
+    /*package*/ void onConfigChange(@Nonnull EnvInjectPluginConfiguration config) {
+       VIEW_INJECTED_VARS.setEnabled(config.isEnablePermissions()); 
+    }
+
+    @Nonnull
+    public EnvInjectPluginConfiguration getConfiguration() {
+        final EnvInjectPluginConfiguration config = EnvInjectPluginConfiguration.getInstance();
+        return config != null ? config : EnvInjectPluginConfiguration.getDefault();
+    }
+    
+    /**
+     * Checks if the current user can view injected variables in the run.
+     * @param run Run to be checked
+     * @return true if the injected variables can be displayed.
+     */
+    @Restricted(NoExternalUse.class)
+    public static boolean canViewInjectedVars(@Nonnull Run<?,?> run) {
+        // We allow security engines to block the output
+        if (VIEW_INJECTED_VARS.getEnabled() &&  !run.hasPermission(VIEW_INJECTED_VARS)) {
+            return false;
+        }
+        
+        // Last check - global configs
+        final EnvInjectPluginConfiguration configuration = getInstance().getConfiguration();
+        return !configuration.isHideInjectedVars();
+    }
+    
+    @Override 
+    public void start() throws Exception {
+        VIEW_INJECTED_VARS.setEnabled(getConfiguration().isEnablePermissions());
+    }  
+    
+    // TODO: Replace by Jenkins::getActiveInstance() in 1.590+
+    @Nonnull
+    @Restricted(NoExternalUse.class)
+    public static Jenkins getJenkinsInstance() throws IllegalStateException {
+        final Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            throw new IllegalStateException("Jenkins instance is not ready");
+        }
+        return jenkins;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginAction.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginAction.java
@@ -8,6 +8,7 @@ import org.jenkinsci.lib.envinject.EnvInjectAction;
 
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 
 /**
  * @author Gregory Boissinot
@@ -18,7 +19,32 @@ public class EnvInjectPluginAction extends EnvInjectAction implements Environmen
         super(build, envMap);
     }
 
+    @Override
+    public String getIconFileName() {
+        if (!EnvInjectPlugin.canViewInjectedVars(getOwner())) {
+            return null;
+        }
+        return super.getIconFileName();
+    }
+
+    @Override
+    public String getUrlName() {
+        if (!EnvInjectPlugin.canViewInjectedVars(getOwner())) {
+            return null;
+        }
+        return super.getUrlName();
+    }
+ 
+    @Override
     public Object getTarget() {
+        if (!EnvInjectPlugin.canViewInjectedVars(getOwner())) {
+            return EnvInjectVarList.HIDDEN;
+        }
+        return getEnvInjectVarList();
+    }
+    
+    @Nonnull
+    private EnvInjectVarList getEnvInjectVarList() {
         return new EnvInjectVarList(Maps.transformEntries(envMap,
                 new Maps.EntryTransformer<String, String, String>() {
                     public String transformEntry(String key, String value) {
@@ -29,7 +55,7 @@ public class EnvInjectPluginAction extends EnvInjectAction implements Environmen
     }
 
     public void buildEnvVars(AbstractBuild<?, ?> build, EnvVars env) {
-        EnvInjectVarList varList = (EnvInjectVarList) getTarget();
+        final EnvInjectVarList varList = getEnvInjectVarList();
         Map<String, String> envMap = varList.getEnvMap();
         if (envMap != null) {
             env.putAll(envMap);

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration.java
@@ -1,0 +1,116 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.envinject;
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.Extension;
+import hudson.XmlFile;
+import java.io.File;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import static org.jenkinsci.plugins.envinject.EnvInjectPlugin.getJenkinsInstance;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+/**
+ * Configuration of {@link EnvInjectPlugin}.
+ * @author Oleg Nenashev
+ * @since 1.92
+ */
+@Extension
+public class EnvInjectPluginConfiguration extends GlobalConfiguration {
+    
+    private static final EnvInjectPluginConfiguration DEFAULT = 
+            new EnvInjectPluginConfiguration(false, false);
+            
+    private boolean hideInjectedVars;
+
+    private boolean enablePermissions;
+
+    public EnvInjectPluginConfiguration() {
+        load();
+    }
+    
+    public EnvInjectPluginConfiguration(boolean hideInjectedVars, boolean enablePermissions) {
+        this.hideInjectedVars = hideInjectedVars;
+        this.enablePermissions = enablePermissions;
+    }
+
+    public boolean isHideInjectedVars() {
+        return hideInjectedVars;
+    }
+
+    public boolean isEnablePermissions() {
+        return enablePermissions;
+    }
+ 
+    /**
+     * Gets the default configuration of {@link EnvInjectPlugin}
+     * @return Default configuration
+     */
+    public static final @Nonnull EnvInjectPluginConfiguration getDefault() {
+        return DEFAULT;
+    }
+
+    @Override
+    protected XmlFile getConfigFile() {
+        return new XmlFile(Jenkins.XSTREAM, new File(getJenkinsInstance().getRootDir(), 
+                "envinject-plugin-configuration.xml"));
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        final boolean newEnablePermissions = json.getBoolean("enablePermissions");
+        final boolean newHideInjectedVars = json.getBoolean("hideInjectedVars");
+        return configure(newHideInjectedVars, newEnablePermissions);
+    }
+    
+    /**
+     * Configuration method for testing purposes.
+     * @param hideInjectedVars Hide injected variables actions
+     * @param enablePermissions Enables permissions in {@link EnvInjectPlugin}.
+     * @return true if the configuration successful
+     * @throws IllegalStateException Cannot retrieve the plugin config instance
+     */
+    @VisibleForTesting
+    /*package*/ static boolean configure(boolean hideInjectedVars, boolean enablePermissions)  {
+        EnvInjectPluginConfiguration instance = getInstance();
+        if (instance == null) {
+            throw new IllegalStateException("Cannot retrieve the plugin config instance");
+        }
+        instance.hideInjectedVars = hideInjectedVars;
+        instance.enablePermissions = enablePermissions;
+        EnvInjectPlugin.getInstance().onConfigChange(instance);
+        instance.save();
+        return true;
+    }
+    
+    @CheckForNull
+    public static EnvInjectPluginConfiguration getInstance() {
+        return EnvInjectPluginConfiguration.all().get(EnvInjectPluginConfiguration.class);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectVarList.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectVarList.java
@@ -10,6 +10,7 @@ import javax.servlet.ServletOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.StringWriter;
+import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -20,6 +21,12 @@ import java.util.TreeMap;
 public class EnvInjectVarList implements Serializable {
 
     private Map<String, String> envVars = new TreeMap<String, String>();
+    
+    /**
+     * Empty variables list, which should be returned if the variables are hidden
+     * due to the security settings.
+     */
+    public static final EnvInjectVarList HIDDEN = new Hidden();
 
     public EnvInjectVarList(Map<String, String> envMap) {
         if (envMap != null) {
@@ -124,6 +131,18 @@ public class EnvInjectVarList implements Serializable {
         sb.delete(0, 1);
         outputStream.write(sb.toString().getBytes());
         outputStream.write("]}}".getBytes());
+    }
+    
+    //TODO: Throw errors in responses?
+    /**
+     * Implements an {@link EnvInjectVarList}, which does not provide any variables.
+     */
+    private static class Hidden extends EnvInjectVarList {
+        private static final long serialVersionUID = 1L;
+
+        public Hidden() {
+            super(Collections.<String,String>emptyMap());
+        }  
     }
 
 }

--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration/config.jelly
@@ -1,0 +1,37 @@
+<!--
+
+    The MIT License (MIT)
+
+    Copyright (c) 2015, CloudBees, Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" 
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:sl="/hudson/plugins/sidebar_link">
+  <f:section title="${%Environment Injector Plugin}" description="${%Settings of the EnvInject plugin}">
+    <f:entry field="enablePermissions" title="${%enablePermissions.title}">
+      <f:checkbox/>
+    </f:entry>
+    <f:entry field="hideInjectedVars" title="${%hideInjectedVars.title}">
+      <f:checkbox/>
+    </f:entry>
+  </f:section>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration/config.properties
@@ -1,0 +1,2 @@
+hideInjectedVars.title=Do not show injected variables
+enablePermissions.title=Enable permissions

--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration/help-enablePermissions.html
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration/help-enablePermissions.html
@@ -1,0 +1,7 @@
+<div>
+  Enables all permissions in EnvInject plugin.
+  <p/>
+  <b>Warning!</b> If you enable this option, users may lose an access to 
+  environment variables list. A manual reconfiguration of permissions will be
+  required.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration/help-hideInjectedVars.html
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration/help-hideInjectedVars.html
@@ -1,0 +1,6 @@
+<div>
+  Globally disables links and REST API methods, which allow to retrieve lists of
+  injected variables. This option allows to avoid security risks if sensitive
+  variables like passwords are being injected to new variables using the plugin.
+  See more details on the plugin Wiki page.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/envinject/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/Messages.properties
@@ -3,4 +3,7 @@ envinject.wrapper.displayName=Inject environment variables to the build process
 envinject.addVars.displayName=Inject environment variables
 envinject.nodeProperty.displayName=Prepare jobs environment
 
+envinject.permissions.title=Env. Inject
+envinject.permissions.viewVars.description=View injected environment variables
+
 EnvInjectPasswordWrapper.DisplayName=Inject passwords to the build as environment variables

--- a/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectPluginActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectPluginActionTest.java
@@ -1,0 +1,151 @@
+package org.jenkinsci.plugins.envinject;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.User;
+import hudson.security.ACL;
+import hudson.security.AccessControlled;
+import hudson.security.GlobalMatrixAuthorizationStrategy;
+import hudson.security.Permission;
+import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
+import org.acegisecurity.Authentication;
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.acegisecurity.userdetails.UsernameNotFoundException;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.Before;
+import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.SingleFileSCM;
+
+/**
+ * Tests for {@link EnvInjectPluginAction}.
+ * @author Oleg Nenashev
+ */
+public class EnvInjectPluginActionTest {
+        
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    
+    private FreeStyleProject p;
+    private CaptureEnvironmentBuilder capture;
+    
+    @Before
+    public void prepareProject() throws Exception {
+        p = j.createFreeStyleProject();
+
+        EnvInjectBuildWrapper wrapper = new EnvInjectBuildWrapper();
+        p.getBuildWrappersList().add(wrapper);
+        wrapper.setInfo(new EnvInjectJobPropertyInfo(null, "FOO=BAR", null, null, null, false));
+        
+        capture = new CaptureEnvironmentBuilder();
+        p.getBuildersList().add(capture);
+    }
+    
+    @Test
+    public void actionSanityTest() throws Exception {
+        // Run build and retrieve results
+        FreeStyleBuild build = j.buildAndAssertSuccess(p);
+        assertEquals("BAR", capture.getEnvVars().get("FOO"));
+        assertEquals("BAR", build.getEnvironment(TaskListener.NULL).get("FOO"));
+        
+        // Check action
+        EnvInjectPluginAction action = build.getAction(EnvInjectPluginAction.class);
+        assertNotNull("EnvInjectPluginAction has not been injected", action);
+        Object target = action.getTarget();
+        assertTrue(target instanceof EnvInjectVarList);
+        EnvInjectVarList vars = (EnvInjectVarList)target;
+        assertEquals("BAR", vars.getEnvMap().get("FOO"));
+        
+        // Check that action is visible
+        assertNotNull(action.getIconFileName());
+        assertNotNull(action.getUrlName());
+    }
+    
+    @Test
+    public void hideActionGlobally() throws Exception {
+        final EnvInjectPlugin plugin = EnvInjectPlugin.getInstance();
+        EnvInjectPluginConfiguration.configure(true, false);
+        
+        // Run build and retrieve results
+        FreeStyleBuild build = j.buildAndAssertSuccess(p);
+        assertEquals("BAR", capture.getEnvVars().get("FOO"));
+        assertEquals("BAR", build.getEnvironment(TaskListener.NULL).get("FOO"));
+        
+        // Check action
+        EnvInjectPluginAction action = build.getAction(EnvInjectPluginAction.class);
+        assertNotNull("EnvInjectPluginAction has not been injected", action);
+        Object target = action.getTarget();
+        assertNull(action.getIconFileName());
+        assertNull(action.getUrlName());
+        
+        assertEquals("Injected variables should be hidden", EnvInjectVarList.HIDDEN, target);
+        assertFalse("Users should have no permission to see injected vars", 
+                canViewInjectedVars(User.getUnknown(), build));
+    }
+    
+    @Test
+    public void hideActionViaPermissions() throws Exception {
+        // Enable permissions
+        final EnvInjectPlugin plugin = EnvInjectPlugin.getInstance();
+        EnvInjectPluginConfiguration.configure(false, true);
+        
+        // Create a test user
+        User user = User.get("testUser", true, null);
+             
+        final GlobalMatrixAuthorizationStrategy strategy = new GlobalMatrixAuthorizationStrategy();
+        strategy.add(Jenkins.READ, user.getId());
+        strategy.add(Item.READ, user.getId());
+        strategy.add(Item.DISCOVER, user.getId());
+        j.jenkins.setAuthorizationStrategy(strategy);
+        
+        // Run build and retrieve results
+        FreeStyleBuild build = j.buildAndAssertSuccess(p);
+        assertFalse("User should have no View Injected Vars permission", 
+                hasPermission(user, build, EnvInjectPlugin.VIEW_INJECTED_VARS));
+        assertFalse("User should have no permission to see injected vars", 
+                canViewInjectedVars(user, build));
+            
+        // Grant permissions and check the results 
+        strategy.add(EnvInjectPlugin.VIEW_INJECTED_VARS, user.getId());
+        assertTrue("User should have the View Injected Vars permission", 
+                hasPermission(user, build, EnvInjectPlugin.VIEW_INJECTED_VARS));
+        assertTrue("User should have a permission to see injected vars", 
+                canViewInjectedVars(user, build));
+    }
+    
+    
+    private boolean hasPermission(User user, AccessControlled item, Permission permission ) 
+            throws AssertionError {
+        SecurityContext initialContext = null;
+        try {
+            Authentication auth = user.impersonate();
+            initialContext = hudson.security.ACL.impersonate(auth);
+            return item.hasPermission(permission);
+        } catch (UsernameNotFoundException ex) {
+            throw new AssertionError("The specified user is not found", ex);
+        } finally {
+            if (initialContext != null) {
+                SecurityContextHolder.setContext(initialContext);
+            }
+        }
+    }
+    
+    private boolean canViewInjectedVars(@Nonnull User user, @Nonnull Run<?,?> run) 
+            throws UsernameNotFoundException {
+        SecurityContext initialContext = null;
+        Authentication auth = user.impersonate();
+        initialContext = hudson.security.ACL.impersonate(auth);
+        try {
+            return EnvInjectPlugin.canViewInjectedVars(run);
+        } finally {
+            SecurityContextHolder.setContext(initialContext);
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectPluginConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectPluginConfigurationTest.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.plugins.envinject;
+
+import java.io.IOException;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Tests for {@link EnvInjectPluginConfiguration}.
+ * @author Oleg Nenashev
+ */
+public class EnvInjectPluginConfigurationTest {
+    
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    
+    @Test
+    public void testRoundTrip() throws Exception {
+        final EnvInjectPlugin plugin = EnvInjectPlugin.getInstance();
+        
+        // Launch roundtrips with different params
+        testRoundtrip(new EnvInjectPluginConfiguration(true, false));
+        testRoundtrip(new EnvInjectPluginConfiguration(false, true));
+        testRoundtrip(new EnvInjectPluginConfiguration(false, false));
+    }
+    
+    private void testRoundtrip(EnvInjectPluginConfiguration config) throws IOException {
+        final EnvInjectPlugin plugin = EnvInjectPlugin.getInstance();
+        EnvInjectPluginConfiguration.configure(config.isHideInjectedVars(), config.isEnablePermissions());
+        assertEquals("Value of enablePermissions differs after the configure() call",
+                config.isEnablePermissions(), plugin.getConfiguration().isEnablePermissions());
+        assertEquals("Value of hideInjectedVars differs after the configure() call",
+                config.isHideInjectedVars(), plugin.getConfiguration().isHideInjectedVars());
+        plugin.save();
+        
+        // Reload from disk
+        EnvInjectPluginConfiguration reloaded = new EnvInjectPluginConfiguration();
+        assertEquals("Value of enablePermissions differs after the reload", 
+                config.isEnablePermissions(), reloaded.isEnablePermissions());
+        assertEquals("Value of hideInjectedVars differs after the reload", 
+                config.isHideInjectedVars(), reloaded.isHideInjectedVars());
+    }
+}


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-29867

In several cases Jenkins users may expose passwords as a plain text in "Injected variables" action (e.g. password reassigning for a non-sensitive variable). It may make sense to add an option, which completely prohibits the exposure of environment variables.

- [x] - ViewVars permissions
- [x] - Global option, which allows to hide envinject actions
- [x] - Unit tests
- [x] - Bump the dependency on https://github.com/jenkinsci/envinject-lib after the release of https://github.com/jenkinsci/envinject-lib/pull/6

Depends on https://github.com/jenkinsci/envinject-lib/pull/6

@reviewbybees