### PR TITLE
Refactoring (UX): Hide  options from the global EnvInject configuration

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration/config.jelly
@@ -27,11 +27,13 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" 
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:sl="/hudson/plugins/sidebar_link">
   <f:section title="${%Environment Injector Plugin}" description="${%Settings of the EnvInject plugin}">
-    <f:entry field="enablePermissions" title="${%enablePermissions.title}">
-      <f:checkbox/>
-    </f:entry>
-    <f:entry field="hideInjectedVars" title="${%hideInjectedVars.title}">
-      <f:checkbox/>
-    </f:entry>
+    <f:advanced title="${%Security options}">
+      <f:entry field="enablePermissions" title="${%enablePermissions.title}">
+        <f:checkbox/>
+      </f:entry>
+      <f:entry field="hideInjectedVars" title="${%hideInjectedVars.title}">
+        <f:checkbox/>
+      </f:entry>
+    </f:advanced>
   </f:section>
 </j:jelly>


### PR DESCRIPTION
The change moves both security options to the Advanced section

@reviewbybees 