### PR TITLE
Fixes JENKINS-23274: remove log of script content

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectEnvVars.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectEnvVars.java
@@ -121,7 +121,7 @@ public class EnvInjectEnvVars implements Serializable {
             return new HashMap<String, String>();
         }
 
-        logger.info(String.format("Evaluation the following Groovy script content: %n%s%n", scriptContent));
+        logger.info("Evaluating the Groovy script content");
 
         Binding binding = new Binding();
         String jobName = envVars.get("JOB_NAME");


### PR DESCRIPTION
Avoids the script content appearing in the build output entirely. This is the simplest possible change to fix this issue, but it also seems the most suitable.

This probably isn't the most high value issue against the plugin, but it would clear up my build logs so it would be nice. Thoughts?