### PR TITLE
[FIXED JENKINS-32693] - Fix BuildCauseRetriever when AbstractBuild has Null CauseAction

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/service/BuildCauseRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/BuildCauseRetriever.java
@@ -33,13 +33,19 @@ public class BuildCauseRetriever {
 
     public Map<String, String> getTriggeredCause(AbstractBuild<?, ?> build) {
         CauseAction causeAction = build.getAction(CauseAction.class);
-        List<Cause> buildCauses = causeAction.getCauses();
         Map<String, String> env = new HashMap<String, String>();
         List<String> directCauseNames = new ArrayList<String>();
         Set<String> rootCauseNames = new LinkedHashSet<String>();
-        for (Cause cause : buildCauses) {
-            directCauseNames.add(getTriggerName(cause));
-            insertRootCauseNames(rootCauseNames, cause, 0);
+
+        if (causeAction != null) {
+            List<Cause> buildCauses = causeAction.getCauses();
+            for (Cause cause : buildCauses) {
+                directCauseNames.add(getTriggerName(cause));
+                insertRootCauseNames(rootCauseNames, cause, 0);
+            }
+        } else {
+            directCauseNames.add("UNKNOWN");
+            rootCauseNames.add("UNKNOWN");
         }
         env.putAll(buildCauseEnvironmentVariables(ENV_CAUSE, directCauseNames));
         env.putAll(buildCauseEnvironmentVariables(ENV_ROOT_CAUSE, rootCauseNames));

--- a/src/test/java/org/jenkinsci/plugins/envinject/sevice/BuildCauseRetrieverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/sevice/BuildCauseRetrieverTest.java
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.envinject.sevice;
+
+import hudson.model.AbstractBuild;
+import hudson.model.CauseAction;
+import org.jenkinsci.plugins.envinject.EnvInjectPluginAction;
+import org.jenkinsci.plugins.envinject.service.BuildCauseRetriever;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class BuildCauseRetrieverTest {
+
+    private AbstractBuild build;
+
+    private BuildCauseRetriever buildCause;
+
+    @Before
+    public void setUp() {
+        build = mock(AbstractBuild.class);
+        buildCause = new BuildCauseRetriever();
+    }
+
+    @Test
+    public void abstractBuildWithNullCauseActionReturnsUnknown() throws Exception {
+        when(build.getAction(CauseAction.class)).thenReturn(null);
+        Map<String, String> envVars = buildCause.getTriggeredCause(build);
+        assertTrue(envVars.get("BUILD_CAUSE").equals("UNKNOWN"));
+    }
+
+}


### PR DESCRIPTION
Fixes the issue mentioned in https://groups.google.com/forum/#!topic/jenkinsci-dev/keV6a_YtzD0