### PR TITLE
[FIXED JENKINS-30028] Remove logging from password wrapper decorateLogger

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPasswordWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPasswordWrapper.java
@@ -79,6 +79,14 @@ public class EnvInjectPasswordWrapper extends BuildWrapper {
 
     @Override
     public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
+        EnvInjectLogger logger = new EnvInjectLogger(listener);
+        if (isInjectGlobalPasswords()) {
+            logger.info("Inject global passwords.");
+        }
+        if (isMaskPasswordParameters()) {
+            logger.info("Mask passwords passed as build parameters.");
+        }
+
         return new Environment() {
         };
     }
@@ -113,19 +121,11 @@ public class EnvInjectPasswordWrapper extends BuildWrapper {
     @Override
     public OutputStream decorateLogger(AbstractBuild build, OutputStream outputStream) throws IOException, InterruptedException, Run.RunnerAbortedException {
         try {
-            EnvInjectLogger logger = new EnvInjectLogger(new StreamTaskListener(outputStream));
-
-            if (isInjectGlobalPasswords()) {
-                logger.info("Inject global passwords.");
-            }
-
             // Decorate passwords provided by EnvInject Plugin (globals and locals)
             List<String> passwords2decorate = Lists.newArrayList(Lists.transform(getEnvInjectPasswordEntries(), PASSWORD_ENTRY_TO_VALUE));
 
             // Decorate passwords passed as build parameters
             if (isMaskPasswordParameters()) {
-                logger.info("Mask passwords passed as build parameters.");
-            
                 ParametersAction parametersAction = build.getAction(ParametersAction.class);
                 if (parametersAction != null) {
                     List<ParameterValue> parameters = parametersAction.getParameters();


### PR DESCRIPTION
[JENKINS-30028](https://issues.jenkins-ci.org/browse/JENKINS-30028)

When the Timestamper build wrapper runs first, the messages logged produced by EnvInjectPasswordWrapper.decorateLogger do not receive timestamps. Fix this by logging these messages from setUp instead.

I was able to reproduce this by using the [ordinal value](https://github.com/jenkinsci/jenkins/blob/2893fd3/core/src/main/java/hudson/Extension.java#L82) to force the Timestamper plugin to load first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/envinject-plugin/87)
<!-- Reviewable:end -->
