### PR TITLE
JENKINS-30467 support common cases of recursive variables

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectEnvVars.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectEnvVars.java
@@ -201,7 +201,6 @@ public class EnvInjectEnvVars implements Serializable {
         return variables;
     }
 
-
     public void resolveVars(Map<String, String> variables, Map<String, String> env) {
 
         //Resolve variables against env
@@ -218,7 +217,11 @@ public class EnvInjectEnvVars implements Serializable {
             int previousNbUnresolvedVar = nbUnresolvedVar;
             nbUnresolvedVar = 0;
             for (Map.Entry<String, String> entry : variables.entrySet()) {
-                String value = Util.replaceMacro(entry.getValue(), variables);
+                Map<String, String> resolveVariables = new HashMap<String, String>(variables);
+                // avoid self reference expansion
+                // FOO=$FOO-X -> FOO=$FOO-X-X -> FOO=$FOO-X-X-X etc.
+                resolveVariables.remove(entry.getKey());
+                String value = Util.replaceMacro(entry.getValue(), resolveVariables);
                 entry.setValue(value);
                 if (isUnresolvedVar(value)) {
                     nbUnresolvedVar++;

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesVariablesRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesVariablesRetriever.java
@@ -59,7 +59,18 @@ public class PropertiesVariablesRetriever implements FilePath.FileCallable<Map<S
             if (propertiesContent != null) {
                 PropertiesGetter propertiesGetter = new PropertiesGetter();
                 logger.info(String.format("Injecting as environment variables the properties content %n%s%n", propertiesGetter.getPropertiesContentFromMapObject(propertiesContent)));
-                result.putAll(propertiesContent);
+                for (Map.Entry<String, String> entry : propertiesContent.entrySet()) {
+                    String key = entry.getKey();
+                    String value = entry.getValue();
+                    if (result.containsKey(key)) {
+                        // a variable is defined in both propertiesFilePath and propertiesContent
+                        // instead of just overwriting it we possibly resolve it against the old value
+                        Map<String, String> oldValueMap = new LinkedHashMap<String, String>();
+                        oldValueMap.put(key, result.get(key));
+                        value = Util.replaceMacro(value, oldValueMap);
+                    }
+                    result.put(key, value);
+                }
                 logger.info("Variables injected successfully.");
             }
 

--- a/src/test/java/org/jenkinsci/plugins/envinject/sevice/PropertiesGetterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/sevice/PropertiesGetterTest.java
@@ -3,8 +3,10 @@ package org.jenkinsci.plugins.envinject.sevice;
 import org.jenkinsci.plugins.envinject.service.PropertiesGetter;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -45,7 +47,10 @@ public class PropertiesGetterTest {
         entryMap.put("key3", "value3");
         String content = propertiesGetter.getPropertiesContentFromMapObject(entryMap);
         assertNotNull(content);
-        assertEquals("key3=value3\nkey2=value2\nkey1=value1", content);
+        List<String> lines = Arrays.asList(content.split("\n"));
+        assertTrue(lines.contains("key1=value1"));
+        assertTrue(lines.contains("key2=value2"));
+        assertTrue(lines.contains("key3=value3"));
     }
 
 }


### PR DESCRIPTION
on a matrix job we had something like this line in "Properties Content":
`PATH=$WORKSPACE/git_checkout/bin:${PATH}`

it expanded recursively (`WORKSPACE` being quite long already for matrix runners) and `PATH` grew very large and I think it caused build failures later, where calling bash failed with:
`Argument list too long`

duplicate issues: JENKINS-30446, JENKINS-30445, JENKINS-30444

similar PR: #73 

Regarding changes in `PropertiesVariablesRetriever`:
this logic should probably be re-used more often across the whole code base instead of plain `putAll`, which just overwrites values.
Currently there are still many inconsistencies regarding referencing previously defined variables (see comment in Test `injectTextExtendSysEnvVar` for an example) but fixing all those issues is outside of the scope of this PR.

I adjusted `PropertiesGetterTest` because it failed on my system (ubuntu xenial, jdk 1.8.0_91) with inverse order:
```
Failed tests: 
  PropertiesGetterTest.getPropertiesContentThreeElements:48 expected:<key[3=value3
key2=value2
key1=value1]> but was:<key[1=value1
key2=value2
key3=value3]>
```