### PR TITLE
Fix eating Exceptions

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuildWrapper.java
@@ -105,7 +105,8 @@ public class EnvInjectBuildWrapper extends BuildWrapper implements Serializable 
                 }
             };
         } catch (Throwable throwable) {
-            logger.error("Problems occurs on injecting env vars as a build wrap: " + throwable.getCause());
+            logger.error("Problems occurs on injecting env vars as a build wrap: " + throwable.getMessage());
+            throwable.printStackTrace(logger.getListener().getLogger());
             build.setResult(Result.FAILURE);
             return null;
         }


### PR DESCRIPTION
All exception that has not a cause was eated with null message.
For example a groovy script like this
- `def mydate = Date.parse("yyyy-MM-dd hh:mm:ss", "2014-04-03 1:23:45")`
throw an `AbortException("The evaluated Groovy script must return a Map object.")`

- `out.println(WORKSPACE)` throw a `MissingPropertyException("No such property: WORKSPACE for class: Script1")`

but the only message shown is

> [EnvInject] - [ERROR] - [EnvInject] - [ERROR] - Problems occurs on injecting env vars as a build wrap: null

This changes always permit to know the exactly cause.

_Personally I change Throwable to Exeption because there is not reason to eat Errors like **OOM** **LinkageError** etc. etc..._