### PR TITLE
Update core dependency to 1.609.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.12</version>
+        <version>2.15</version>
     </parent>
 
     <artifactId>envinject</artifactId>
@@ -60,8 +60,8 @@
         <ivy.plugin.version>1.21</ivy.plugin.version>
         <mockito.version>1.10.19</mockito.version>
 
-        <jenkins.version>1.532.3</jenkins.version>
-        <jenkins-test-harness.version>1.532.3</jenkins-test-harness.version>
+        <jenkins.version>1.609.3</jenkins.version>
+        <jenkins-test-harness.version>1.609.3</jenkins-test-harness.version>
         <java.level>6</java.level>
         <java.level.test>${java.level}</java.level.test>
         <findbugs.failOnError>false</findbugs.failOnError>
@@ -115,8 +115,8 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.4</version>
-            <scope>test</scope>
+            <version>1.7</version>
+            <type>jar</type>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectComputerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectComputerListener.java
@@ -7,12 +7,12 @@ import hudson.model.Computer;
 import hudson.model.Hudson;
 import hudson.model.Node;
 import hudson.model.TaskListener;
-import hudson.remoting.Callable;
 import hudson.slaves.ComputerListener;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.NodePropertyDescriptor;
 import hudson.util.DescribableList;
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 import org.jenkinsci.lib.envinject.EnvInjectLogger;
 import org.jenkinsci.plugins.envinject.service.EnvInjectEnvVars;
@@ -36,7 +36,7 @@ public class EnvInjectComputerListener extends ComputerListener implements Seria
 
         //Get env vars for the current node
         Map<String, String> nodeEnvVars = nodePath.act(
-                new Callable<Map<String, String>, IOException>() {
+                new MasterToSlaveCallable<Map<String, String>, IOException>() {
                     public Map<String, String> call() throws IOException {
                         return EnvVars.masterEnvVars;
                     }
@@ -92,7 +92,7 @@ public class EnvInjectComputerListener extends ComputerListener implements Seria
         
         //Get env vars for the current node
         Map<String, String> nodeEnvVars = nodePath.act(
-                new Callable<Map<String, String>, IOException>() {
+                new MasterToSlaveCallable<Map<String, String>, IOException>() {
                     public Map<String, String> call() throws IOException {
                         return EnvVars.masterEnvVars;
                     }

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectActionSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectActionSetter.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.envinject.service;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
-import hudson.remoting.Callable;
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 import org.jenkinsci.plugins.envinject.EnvInjectPluginAction;
 
@@ -33,7 +33,7 @@ public class EnvInjectActionSetter implements Serializable {
             envInjectAction.overrideAll(build.getSensitiveBuildVariables(), envMap);
         } else {
             if (rootPath != null) {
-                envInjectAction = new EnvInjectPluginAction(build, rootPath.act(new Callable<Map<String, String>, EnvInjectException>() {
+                envInjectAction = new EnvInjectPluginAction(build, rootPath.act(new MasterToSlaveCallable<Map<String, String>, EnvInjectException>() {
                     public Map<String, String> call() throws EnvInjectException {
                         HashMap<String, String> result = new HashMap<String, String>();
                         result.putAll(EnvVars.masterEnvVars);

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.envinject.service;
 import hudson.EnvVars;
 import hudson.Main;
 import hudson.Platform;
-import hudson.remoting.Callable;
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 
 import java.lang.reflect.Field;
@@ -12,7 +12,7 @@ import java.lang.reflect.Modifier;
 /**
  * @author Gregory Boissinot
  */
-public class EnvInjectMasterEnvVarsSetter implements Callable<Void, EnvInjectException> {
+public class EnvInjectMasterEnvVarsSetter extends MasterToSlaveCallable<Void, EnvInjectException> {
 
     private EnvVars enVars;
 

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvironmentVariablesNodeLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvironmentVariablesNodeLoader.java
@@ -5,9 +5,9 @@ import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Hudson;
 import hudson.model.Node;
-import hudson.remoting.Callable;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 import org.jenkinsci.lib.envinject.EnvInjectLogger;
 
@@ -42,7 +42,7 @@ public class EnvironmentVariablesNodeLoader implements Serializable {
 
             //Get env vars for the current node
             Map<String, String> nodeEnvVars = nodePath.act(
-                    new Callable<Map<String, String>, IOException>() {
+                    new MasterToSlaveCallable<Map<String, String>, IOException>() {
                         public Map<String, String> call() throws IOException {
                             return EnvVars.masterEnvVars;
                         }

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesVariablesRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesVariablesRetriever.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.envinject.service;
 import hudson.FilePath;
 import hudson.Util;
 import hudson.remoting.VirtualChannel;
+import jenkins.MasterToSlaveFileCallable;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 import org.jenkinsci.lib.envinject.EnvInjectLogger;
 
@@ -14,7 +15,7 @@ import java.util.Map;
 /**
  * @author Gregory Boissinot
  */
-public class PropertiesVariablesRetriever implements FilePath.FileCallable<Map<String, String>> {
+public class PropertiesVariablesRetriever extends MasterToSlaveFileCallable<Map<String, String>> {
 
     private String propertiesFilePath;
 

--- a/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectPluginActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectPluginActionTest.java
@@ -72,6 +72,7 @@ public class EnvInjectPluginActionTest {
     public void hideActionGlobally() throws Exception {
         final EnvInjectPlugin plugin = EnvInjectPlugin.getInstance();
         EnvInjectPluginConfiguration.configure(true, false);
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         
         // Run build and retrieve results
         FreeStyleBuild build = j.buildAndAssertSuccess(p);
@@ -95,6 +96,7 @@ public class EnvInjectPluginActionTest {
         // Enable permissions
         final EnvInjectPlugin plugin = EnvInjectPlugin.getInstance();
         EnvInjectPluginConfiguration.configure(false, true);
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         
         // Create a test user
         User user = User.get("testUser", true, null);


### PR DESCRIPTION
It supersedes #82. The reason for the upgrade is a need to pick security fixes available in newer Jenkins core versions. 1.609.3 is the target release, because newer version do not support Java 6.

After this release I hope to jump to Java 7 shortly since it could help with plugin code quality fixes.