### PR TITLE
[JENKINS-23666] - Document the current behavior of NodeProperties

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectNodeProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectNodeProperty/config.jelly
@@ -9,9 +9,7 @@
                 checked="${it.unsetSystemVariables}" default="${true}"/>
     </f:entry>
 
-    <f:entry field="propertiesFilePath"
-             title="${%Properties File Path}"
-             help="/descriptor/org.jenkinsci.plugins.envinject.EnvInjectJobProperty/help/propertiesFilePath">
+    <f:entry field="propertiesFilePath" title="${%Properties File Path}">
         <f:textbox
                 name="propertiesFilePath"
                 value="${it.propertiesFilePath}"/>

--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectNodeProperty/help-propertiesFilePath.html
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectNodeProperty/help-propertiesFilePath.html
@@ -1,0 +1,21 @@
+<div>
+  <p>
+    Specifies location of a property file with additional variables to be injected.
+  </p>
+  <p>
+    If you specify a relative path, then Jenkins will firstly try to resolve this path
+    against the HOME directory of the slave/master user.
+    If it fails to find a file there, then it will try resolution against the 
+    working directory of the node/slave.
+    This behavior is a subject to change 
+    (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-23666">JENKINS-23666</a>).
+  </p>
+  <p>
+    <b>Warning!</b> The variables specified by this file are being cached and refreshed
+    only on node connection.
+    If you modify this entry or the file contents for a Jenkins slave/agent, 
+    will need to reconnect this slave/agent to the master in order to get
+    changes applied.
+    If you modify settings for the Master node, you will have to restart the master.
+  </p>
+</div>


### PR DESCRIPTION
Just add a warning regarding [JENKINS-23666](https://issues.jenkins-ci.org/browse/JENKINS-23666), which got several issues in Jenkins. Also added a node regarding the startup-only behavior.

Occasionally got into [JENKINS-38487](https://issues.jenkins-ci.org/browse/JENKINS-38487) during testing. It's a core bug IMHO, still exists in the last version.

@reviewbybees @rsandell  @recena 