### PR TITLE
[FIXED JENKINS-38607] - Add explicit compatibility notice for the JENKINS-31573 change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,15 +73,18 @@
     </scm>
 
     <build>
-
-        <plugins>
-            <plugin>
-                <groupId>org.jenkins-ci.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <version>1.98</version>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
+      <plugins>
+        <plugin>
+          <groupId>org.jenkins-ci.tools</groupId>
+          <artifactId>maven-hpi-plugin</artifactId>
+          <extensions>true</extensions>
+          <configuration>
+            <!-- Fix of JENKINS-31573 changed the property file parsing approach. 
+                 Now it follows the Java property file standard. -->
+            <compatibleSinceVersion>1.93</compatibleSinceVersion>
+          </configuration>
+        </plugin>
+      </plugins>
     </build>
 
     <dependencies>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
     This plugin makes it possible to set an environment for the builds.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectBuilder/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectNodeProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectNodeProperty/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectNodeProperty/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectNodeProperty/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:section title="${%Global Passwords}">

--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectPasswordWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectPasswordWrapper/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectVarList/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectVarList/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
     <l:layout title="${it.displayName}">
         <j:invokeStatic var="currentThread" className="java.lang.Thread" method="currentThread"/>


### PR DESCRIPTION
Also updates maven-hpi-version to the version declared in POM

* https://issues.jenkins-ci.org/browse/JENKINS-31573
* https://issues.jenkins-ci.org/browse/JENKINS-38607

@reviewbybees @rsandell @jenkinsci/code-reviewers 