### PR TITLE
fix groovy script example in help text

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectJobPropertyInfo/help-secureGroovyScript.html
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectJobPropertyInfo/help-secureGroovyScript.html
@@ -40,10 +40,10 @@
         <pre><code>
           def stringValue="StRinG";
           if ("upper".equals(CASE)){
-            def map = [COMPUTE_VAR: stringValue.toUpperCase()]
+            def map = ["COMPUTE_VAR": stringValue.toUpperCase()]
             return map
           } else if ("lower".equals(CASE)){
-            def map = [COMPUTE_VAR: stringValue.toLowerCase()]
+            def map = ["COMPUTE_VAR": stringValue.toLowerCase()]
             return map
           } else {
             return null;


### PR DESCRIPTION
In the example in the help text, the key in the returned map should be a string from what I have tested. Otherwise groovy throws an exception like the following:

groovy.lang.MissingPropertyException: No such property: COMPUTE_VAR for class: xxx
