### PR TITLE
[JENKINS-43536] - Avoid usage of AbstractProject/AbstractBuild where possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.24</version>
+        <version>2.26</version>
     </parent>
 
     <artifactId>envinject</artifactId>
@@ -54,14 +54,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
-        <envinject.lib.version>1.25-SNAPSHOT</envinject.lib.version>
+        <envinject.api.version>1.0-SNAPSHOT</envinject.api.version>
         <ivy.plugin.version>1.21</ivy.plugin.version>
         <mockito.version>1.10.19</mockito.version>
-        <jenkins.version>1.609.3</jenkins.version>
-        <java.level>6</java.level>
-        <java.level.test>${java.level}</java.level.test>
+        <jenkins.version>1.625.3</jenkins.version>
+        <java.level>7</java.level>
         <findbugs.failOnError>false</findbugs.failOnError>
     </properties>
 
@@ -98,9 +95,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.lib</groupId>
-            <artifactId>envinject-lib</artifactId>
-            <version>${envinject.lib.version}</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>envinject-api</artifactId>
+            <version>${envinject.api.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <envinject.api.version>1.0-SNAPSHOT</envinject.api.version>
         <ivy.plugin.version>1.21</ivy.plugin.version>
         <mockito.version>1.10.19</mockito.version>
         <jenkins.version>1.625.3</jenkins.version>
@@ -89,15 +88,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version> <!-- assertLogContains is incompatible with whatever hamcrest junit 4.12 adds -->
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>envinject-api</artifactId>
-            <version>${envinject.api.version}</version>
+            <version>1.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.26</version>
+        <version>2.28</version>
     </parent>
 
     <artifactId>envinject</artifactId>
@@ -102,7 +102,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
@@ -118,7 +118,6 @@
             <artifactId>script-security</artifactId>
             <version>1.22</version>
         </dependency>
-        
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
-        <envinject.lib.version>1.24</envinject.lib.version>
+        <envinject.lib.version>1.25-SNAPSHOT</envinject.lib.version>
         <ivy.plugin.version>1.21</ivy.plugin.version>
         <mockito.version>1.10.19</mockito.version>
         <jenkins.version>1.609.3</jenkins.version>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,13 @@
             <artifactId>script-security</artifactId>
             <version>1.22</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectAction.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectAction.java
@@ -5,13 +5,13 @@ import hudson.model.AbstractBuild;
 import hudson.model.Action;
 import org.apache.commons.collections.map.UnmodifiableMap;
 import org.jenkinsci.lib.envinject.EnvInjectException;
-import org.jenkinsci.lib.envinject.service.EnvInjectSavable;
 import org.kohsuke.stapler.StaplerProxy;
 
 import java.io.File;
 import java.io.ObjectStreamException;
 import java.util.Map;
 import java.util.Set;
+import org.jenkinsci.plugins.envinjectapi.util.EnvInjectVarsIO;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -109,12 +109,11 @@ public class EnvInjectAction implements Action, StaplerProxy {
         }
 
         try {
-            EnvInjectSavable dao = new EnvInjectSavable();
             if (rootDir == null) {
-                dao.saveEnvironment(build.getRootDir(), envMap);
+                EnvInjectVarsIO.saveEnvironment(build.getRootDir(), envMap);
                 return this;
             }
-            dao.saveEnvironment(rootDir, envMap);
+            EnvInjectVarsIO.saveEnvironment(rootDir, envMap);
         } catch (EnvInjectException e) {
             e.printStackTrace();
         }
@@ -129,13 +128,12 @@ public class EnvInjectAction implements Action, StaplerProxy {
             return this;
         }
 
-        EnvInjectSavable dao = new EnvInjectSavable();
         Map<String, String> resultMap = null;
         try {
             if (build != null) {
-                resultMap = dao.getEnvironment(build.getRootDir());
+                resultMap = EnvInjectVarsIO.getEnvironment(build.getRootDir());
             } else if (rootDir != null) {
-                resultMap = dao.getEnvironment(rootDir);
+                resultMap = EnvInjectVarsIO.getEnvironment(rootDir);
             }
             if (resultMap != null) {
                 envMap = resultMap;

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuildVariableContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuildVariableContributor.java
@@ -3,13 +3,13 @@ package org.jenkinsci.plugins.envinject;
 import hudson.Extension;
 import hudson.model.*;
 import org.jenkinsci.lib.envinject.EnvInjectException;
-import org.jenkinsci.plugins.envinject.service.EnvInjectVariableGetter;
 import org.jenkinsci.plugins.envinject.service.EnvironmentVariablesNodeLoader;
 
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import org.jenkinsci.lib.envinject.EnvInjectLogger;
+import org.jenkinsci.plugins.envinject.util.RunHelper;
 
 /**
  * Overriding job parameters with environment variables populated by EnvInject plugin
@@ -25,8 +25,7 @@ public class EnvInjectBuildVariableContributor extends BuildVariableContributor 
         //Only for a parameterized job
         if (parameters != null) {
 
-            EnvInjectVariableGetter variableGetter = new EnvInjectVariableGetter();
-            EnvInjectJobProperty envInjectJobProperty = variableGetter.getEnvInjectJobProperty(build);
+            EnvInjectJobProperty envInjectJobProperty = RunHelper.getEnvInjectJobProperty(build);
             if (envInjectJobProperty == null) {
                 // Don't override anything if envinject isn't enabled on this job
                 return;
@@ -35,10 +34,9 @@ public class EnvInjectBuildVariableContributor extends BuildVariableContributor 
             if (!envInjectJobProperty.isOverrideBuildParameters()) return;
 
             //Gather global variables for the current node
-            EnvironmentVariablesNodeLoader environmentVariablesNodeLoader = new EnvironmentVariablesNodeLoader();
             Map<String, String> nodeEnvVars = new HashMap<String, String>();
             try {
-                nodeEnvVars = environmentVariablesNodeLoader.gatherEnvironmentVariablesNode(build, build.getBuiltOn(), new EnvInjectLogger(TaskListener.NULL));
+                nodeEnvVars = EnvironmentVariablesNodeLoader.gatherEnvVarsForNode(build, build.getBuiltOn(), new EnvInjectLogger(TaskListener.NULL));
             } catch (EnvInjectException e) {
                 e.printStackTrace();
             }

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuildVariableContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuildVariableContributor.java
@@ -3,13 +3,13 @@ package org.jenkinsci.plugins.envinject;
 import hudson.Extension;
 import hudson.model.*;
 import org.jenkinsci.lib.envinject.EnvInjectException;
-import org.jenkinsci.lib.envinject.EnvInjectLogger;
 import org.jenkinsci.plugins.envinject.service.EnvInjectVariableGetter;
 import org.jenkinsci.plugins.envinject.service.EnvironmentVariablesNodeLoader;
 
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import org.jenkinsci.lib.envinject.EnvInjectLogger;
 
 /**
  * Overriding job parameters with environment variables populated by EnvInject plugin

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuildWrapper.java
@@ -26,7 +26,7 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.lib.envinject.EnvInjectLogger;
 import org.jenkinsci.plugins.envinject.service.EnvInjectActionSetter;
 import org.jenkinsci.plugins.envinject.service.EnvInjectEnvVars;
-import org.jenkinsci.plugins.envinject.service.EnvInjectVariableGetter;
+import org.jenkinsci.plugins.envinject.util.RunHelper;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -78,13 +78,12 @@ public class EnvInjectBuildWrapper extends BuildWrapper implements Serializable 
         EnvInjectLogger logger = new EnvInjectLogger(listener);
         logger.info("Executing scripts and injecting environment variables after the SCM step.");
 
-        EnvInjectVariableGetter variableGetter = new EnvInjectVariableGetter();
         FilePath ws = build.getWorkspace();
         EnvInjectActionSetter envInjectActionSetter = new EnvInjectActionSetter(ws);
         EnvInjectEnvVars envInjectEnvVarsService = new EnvInjectEnvVars(logger);
 
         try {
-            Map<String, String> previousEnvVars = variableGetter.getEnvVarsPreviousSteps(build, logger);
+            Map<String, String> previousEnvVars = RunHelper.getEnvVarsPreviousSteps(build, logger);
             Map<String, String> injectedEnvVars = new HashMap<String, String>(previousEnvVars);
 
             //Add workspace if not set
@@ -118,7 +117,7 @@ public class EnvInjectBuildWrapper extends BuildWrapper implements Serializable 
             }
 
             //Add or get the existing action to add new env vars
-            envInjectActionSetter.addEnvVarsToEnvInjectBuildAction(build, resultVariables);
+            envInjectActionSetter.addEnvVarsToRun(build, resultVariables);
 
             return new Environment() {
                 @Override

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuilder$1.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuilder$1.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.envinject;
 
 import hudson.RestrictedSince;
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import org.jenkinsci.lib.envinject.EnvInjectAction;
 
@@ -12,17 +13,22 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * @author Gregory Boissinot
+ * @deprecated replaced by {@link EnvInjectBuilder}
  */
 @SuppressWarnings("unused")
 @Restricted(NoExternalUse.class)
 @RestrictedSince("2.1")
+@Deprecated
 public class EnvInjectBuilder$1 extends EnvInjectAction {
 
     private transient String val$resultVariables;
     private transient String this$0;
 
-    public EnvInjectBuilder$1(@Nonnull Run<?, ?> run, @CheckForNull Map<String, String> envMap) {
-        super(run, envMap);
+    public EnvInjectBuilder$1(@Nonnull AbstractBuild build, @CheckForNull Map<String, String> envMap) {
+        super(build, envMap);
     }
-
+    
+    public EnvInjectBuilder$1(@CheckForNull Map<String, String> envMap) {
+        super(envMap);
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuilder$1.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuilder$1.java
@@ -1,23 +1,28 @@
 package org.jenkinsci.plugins.envinject;
 
-import hudson.model.AbstractBuild;
+import hudson.RestrictedSince;
+import hudson.model.Run;
 import org.jenkinsci.lib.envinject.EnvInjectAction;
 
 import java.util.Map;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * @author Gregory Boissinot
  */
 @SuppressWarnings("unused")
+@Restricted(NoExternalUse.class)
+@RestrictedSince("2.1")
 public class EnvInjectBuilder$1 extends EnvInjectAction {
 
     private transient String val$resultVariables;
     private transient String this$0;
 
-    public EnvInjectBuilder$1(@Nonnull AbstractBuild build, @CheckForNull Map<String, String> envMap) {
-        super(build, envMap);
+    public EnvInjectBuilder$1(@Nonnull Run<?, ?> run, @CheckForNull Map<String, String> envMap) {
+        super(run, envMap);
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectBuilder.java
@@ -13,7 +13,6 @@ import hudson.tasks.Builder;
 import org.jenkinsci.lib.envinject.EnvInjectLogger;
 import org.jenkinsci.plugins.envinject.service.EnvInjectActionSetter;
 import org.jenkinsci.plugins.envinject.service.EnvInjectEnvVars;
-import org.jenkinsci.plugins.envinject.service.EnvInjectVariableGetter;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
@@ -21,6 +20,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import org.jenkinsci.plugins.envinject.util.RunHelper;
 
 /**
  * @author Gregory Boissinot
@@ -52,9 +52,7 @@ public class EnvInjectBuilder extends Builder implements Serializable {
         EnvInjectEnvVars envInjectEnvVarsService = new EnvInjectEnvVars(logger);
 
         try {
-
-            EnvInjectVariableGetter variableGetter = new EnvInjectVariableGetter();
-            Map<String, String> previousEnvVars = variableGetter.getEnvVarsPreviousSteps(build, logger);
+            Map<String, String> previousEnvVars = RunHelper.getEnvVarsPreviousSteps(build, logger);
 
             //Get current envVars
             Map<String, String> variables = new HashMap<String, String>(previousEnvVars);
@@ -87,7 +85,7 @@ public class EnvInjectBuilder extends Builder implements Serializable {
             build.addAction(new EnvInjectBuilderContributionAction(resultVariables));
 
             //Add or get the existing action to add new env vars
-            envInjectActionSetter.addEnvVarsToEnvInjectBuildAction(build, resultVariables);
+            envInjectActionSetter.addEnvVarsToRun(build, resultVariables);
 
         } catch (Throwable throwable) {
             logger.error("Problems occurs on injecting env vars as a build step: " + throwable.getMessage());

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectJobProperty.java
@@ -2,13 +2,10 @@ package org.jenkinsci.plugins.envinject;
 
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
-import hudson.model.Descriptor;
 import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
-import jenkins.model.Jenkins;
-import net.sf.json.JSON;
-import net.sf.json.JSONException;
+
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.envinject.model.EnvInjectJobPropertyContributor;
 import org.jenkinsci.plugins.envinject.model.EnvInjectJobPropertyContributorDescriptor;

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectListener.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectListener.java
@@ -298,7 +298,7 @@ public class EnvInjectListener extends RunListener<Run> implements Serializable 
         EnvVars envVars = new EnvVars();
         EnvInjectLogger logger = new EnvInjectLogger(listener);
         EnvInjectPasswordsMasker passwordsMasker = new EnvInjectPasswordsMasker();
-        passwordsMasker.maskPasswordParameterssIfAny(run, envVars, logger);
+        passwordsMasker.maskPasswordParametersIfAny(run, envVars, logger);
 
         if (!(run instanceof MatrixBuild)) {
 

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginAction.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginAction.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Maps;
 import hudson.EnvVars;
 import hudson.model.AbstractBuild;
 import hudson.model.EnvironmentContributingAction;
-import hudson.model.Run;
 import java.util.Collections;
 import org.jenkinsci.lib.envinject.EnvInjectAction;
 
@@ -12,14 +11,30 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import jenkins.model.RunAction2;
 
 /**
  * @author Gregory Boissinot
  */
 public class EnvInjectPluginAction extends EnvInjectAction implements EnvironmentContributingAction {
 
-    public EnvInjectPluginAction(@Nonnull Run<?, ?> run, @CheckForNull Map<String, String> envMap) {
-        super(run, envMap);
+    /**
+     * Constructor.
+     * @deprecated This is a {@link RunAction2} instance, not need to pass build explicitly.
+     *             Use {@link #EnvInjectPluginAction(java.util.Map)}
+     */
+    @Deprecated
+    public EnvInjectPluginAction(@Nonnull AbstractBuild build, @CheckForNull Map<String, String> envMap) {
+        super(build, envMap);
+    }
+    
+    /**
+     * Constructor.
+     * @param envMap Environment variables to be injected
+     * @since 2.1
+     */
+    public EnvInjectPluginAction(@CheckForNull Map<String, String> envMap) {
+        super(envMap);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginAction.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginAction.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Maps;
 import hudson.EnvVars;
 import hudson.model.AbstractBuild;
 import hudson.model.EnvironmentContributingAction;
+import hudson.model.Run;
 import java.util.Collections;
 import org.jenkinsci.lib.envinject.EnvInjectAction;
 
@@ -17,8 +18,8 @@ import javax.annotation.Nonnull;
  */
 public class EnvInjectPluginAction extends EnvInjectAction implements EnvironmentContributingAction {
 
-    public EnvInjectPluginAction(@Nonnull AbstractBuild build, @CheckForNull Map<String, String> envMap) {
-        super(build, envMap);
+    public EnvInjectPluginAction(@Nonnull Run<?, ?> run, @CheckForNull Map<String, String> envMap) {
+        super(run, envMap);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/envinject/model/EnvInjectJobPropertyContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/model/EnvInjectJobPropertyContributor.java
@@ -6,6 +6,7 @@ import hudson.model.*;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
@@ -20,10 +21,37 @@ public abstract class EnvInjectJobPropertyContributor implements ExtensionPoint,
      */
     public abstract void init();
 
-    public abstract Map<String, String> getEnvVars(
+    /**
+     * @deprecated Use {@link #contributeToRun(hudson.model.Run, hudson.model.TaskListener, java.util.Map)}
+     */
+    @Deprecated
+    public Map<String, String> getEnvVars(
             @Nonnull AbstractBuild build, 
-            @Nonnull TaskListener listener) throws EnvInjectException;
+            @Nonnull TaskListener listener) throws EnvInjectException {
+        return Collections.emptyMap();
+    }
 
+    /**
+     * Contributes environment variables to the run.
+     * @param run Run
+     * @param listener Log listener
+     * @param envVars Target collection
+     * @throws EnvInjectException Environment injection error
+     * @since 2.1
+     */
+    @Nonnull
+    public void contributeEnvVarsToRun(
+            @Nonnull Run<?, ?> run, 
+            @Nonnull TaskListener listener,
+            @Nonnull Map<String, String> envVars) throws EnvInjectException {
+        
+        // Fallback to the old method for AbstractBuilds, do nothing for other types
+        if (run instanceof AbstractBuild) {
+            Map<String, String> res = getEnvVars((AbstractBuild)run, listener);
+            envVars.putAll(res);
+        }
+    }
+    
     public Descriptor<EnvInjectJobPropertyContributor> getDescriptor() {
         return Jenkins.getActiveInstance().getDescriptor(getClass());
     }

--- a/src/main/java/org/jenkinsci/plugins/envinject/model/EnvInjectJobPropertyContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/model/EnvInjectJobPropertyContributor.java
@@ -22,7 +22,7 @@ public abstract class EnvInjectJobPropertyContributor implements ExtensionPoint,
     public abstract void init();
 
     /**
-     * @deprecated Use {@link #contributeToRun(hudson.model.Run, hudson.model.TaskListener, java.util.Map)}
+     * @deprecated Use {@link #contributeEnvVarsToRun(hudson.model.Run, hudson.model.TaskListener, java.util.Map)}
      */
     @Deprecated
     public Map<String, String> getEnvVars(

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/BuildCauseRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/BuildCauseRetriever.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.envinject.service;
 
-import hudson.model.AbstractBuild;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.triggers.SCMTrigger;
@@ -15,6 +14,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.Joiner.on;
+import hudson.model.Run;
 import java.util.Locale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -34,8 +34,8 @@ public class BuildCauseRetriever {
     public static final String ENV_ROOT_CAUSE = "ROOT_BUILD_CAUSE";
 
     @Nonnull
-    public Map<String, String> getTriggeredCause(@Nonnull AbstractBuild<?, ?> build) {
-        CauseAction causeAction = build.getAction(CauseAction.class);
+    public Map<String, String> getTriggeredCause(@Nonnull Run<?, ?> run) {
+        CauseAction causeAction = run.getAction(CauseAction.class);
         Map<String, String> env = new HashMap<String, String>();
         List<String> directCauseNames = new ArrayList<String>();
         Set<String> rootCauseNames = new LinkedHashSet<String>();

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/BuildCauseRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/BuildCauseRetriever.java
@@ -14,11 +14,13 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.Joiner.on;
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import java.util.Locale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
+import org.jenkinsci.plugins.envinjectapi.util.EnvVarsResolver;
 
 
 /**
@@ -33,6 +35,15 @@ public class BuildCauseRetriever {
     public static final String ENV_CAUSE = "BUILD_CAUSE";
     public static final String ENV_ROOT_CAUSE = "ROOT_BUILD_CAUSE";
 
+    /**
+     * @deprecated Use {@link EnvVarsResolver#getCauseEnvVars(hudson.model.Run)}
+     */
+    @Nonnull
+    @Deprecated
+    public Map<String, String> getTriggeredCause(@Nonnull AbstractBuild<?, ?> build) {
+        return EnvVarsResolver.getCauseEnvVars(build);
+    }
+    
     @Nonnull
     public Map<String, String> getTriggeredCause(@Nonnull Run<?, ?> run) {
         CauseAction causeAction = run.getAction(CauseAction.class);

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectActionSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectActionSetter.java
@@ -45,6 +45,7 @@ public class EnvInjectActionSetter implements Serializable {
      * @throws EnvInjectException Injection failure
      * @throws IOException Remote operation failure
      * @throws InterruptedException Remote call is interrupted
+     * @since 2.1
      */
     public void addEnvVarsToRun(@Nonnull Run<?, ?> run, @CheckForNull Map<String, String> envMap) 
             throws EnvInjectException, IOException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectActionSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectActionSetter.java
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.envinject.service;
 
 import hudson.EnvVars;
 import hudson.FilePath;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 import org.jenkinsci.plugins.envinject.EnvInjectPluginAction;
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.jenkinsci.plugins.envinject.util.RunHelper;
 
 
 /**
@@ -27,12 +28,12 @@ public class EnvInjectActionSetter implements Serializable {
         this.rootPath = rootPath;
     }
 
-    public void addEnvVarsToEnvInjectBuildAction(@Nonnull AbstractBuild<?, ?> build, @CheckForNull Map<String, String> envMap) 
+    public void addEnvVarsToEnvInjectBuildAction(@Nonnull Run<?, ?> build, @CheckForNull Map<String, String> envMap) 
             throws EnvInjectException, IOException, InterruptedException {
 
         EnvInjectPluginAction envInjectAction = build.getAction(EnvInjectPluginAction.class);
         if (envInjectAction != null) {
-            envInjectAction.overrideAll(build.getSensitiveBuildVariables(), envMap);
+            envInjectAction.overrideAll(RunHelper.getSensitiveBuildVariables(build), envMap);
         } else {
             if (rootPath != null) {
                 envInjectAction = new EnvInjectPluginAction(build, rootPath.act(new MasterToSlaveCallable<Map<String, String>, EnvInjectException>() {
@@ -42,7 +43,7 @@ public class EnvInjectActionSetter implements Serializable {
                         return result;
                     }
                 }));
-                envInjectAction.overrideAll(build.getSensitiveBuildVariables(), envMap);
+                envInjectAction.overrideAll(RunHelper.getSensitiveBuildVariables(build), envMap);
                 build.addAction(envInjectAction);
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectActionSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectActionSetter.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.envinject.service;
 
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.lib.envinject.EnvInjectException;
@@ -32,7 +33,7 @@ public class EnvInjectActionSetter implements Serializable {
      * @deprecated Use {@link #addEnvVarsToRun(hudson.model.Run, java.util.Map)}
      */
     @Deprecated
-    public void addEnvVarsToEnvInjectBuildAction(@Nonnull Run<?, ?> build, @CheckForNull Map<String, String> envMap) 
+    public void addEnvVarsToEnvInjectBuildAction(@Nonnull AbstractBuild<?, ?> build, @CheckForNull Map<String, String> envMap) 
             throws EnvInjectException, IOException, InterruptedException {
         addEnvVarsToRun(build, envMap);
     }

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectPasswordsMasker.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectPasswordsMasker.java
@@ -31,7 +31,7 @@ import javax.annotation.Nonnull;
 public class EnvInjectPasswordsMasker implements Serializable {
 
     /**
-     * @deprecated Use {@link #maskPasswordsIfAny(hudson.model.Run, java.util.Map, org.jenkinsci.lib.envinject.EnvInjectLogger)} 
+     * @deprecated Use {@link #maskPasswordParametersIfAny(hudson.model.Run, java.util.Map, org.jenkinsci.lib.envinject.EnvInjectLogger)} 
      */
     @Deprecated
     public void maskPasswordsIfAny(@Nonnull AbstractBuild run, @Nonnull EnvInjectLogger logger, @Nonnull Map<String, String> envVars) {

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectPasswordsMasker.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectPasswordsMasker.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.envinject.service;
 
 import hudson.matrix.MatrixProject;
 import hudson.matrix.MatrixRun;
+import hudson.model.AbstractBuild;
 import hudson.model.BuildableItemWithBuildWrappers;
 import hudson.model.Descriptor;
 import hudson.model.Job;
@@ -24,11 +25,27 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /**
+ * Masks {@link PasswordParameterValue}s
  * @author Gregory Boissinot
  */
 public class EnvInjectPasswordsMasker implements Serializable {
 
-    public void maskPasswordsIfAny(@Nonnull Run<?, ?> run, @Nonnull EnvInjectLogger logger, @Nonnull Map<String, String> envVars) {
+    /**
+     * @deprecated Use {@link #maskPasswordsIfAny(hudson.model.Run, java.util.Map, org.jenkinsci.lib.envinject.EnvInjectLogger)} 
+     */
+    @Deprecated
+    public void maskPasswordsIfAny(@Nonnull AbstractBuild run, @Nonnull EnvInjectLogger logger, @Nonnull Map<String, String> envVars) {
+        maskPasswordParameterssIfAny(run, envVars, logger);
+    }
+    
+    /**
+     * Masks {@link PasswordParameterValue}s.
+     * @param run Run
+     * @param envVars Target collection with Environment variables to be masked
+     * @param logger Logger
+     * @since 2.1
+     */
+    public void maskPasswordParameterssIfAny(@Nonnull Run<?, ?> run, @Nonnull Map<String, String> envVars, @Nonnull EnvInjectLogger logger) {
         maskPasswordsJobParameterIfAny(run, logger, envVars);
         maskPasswordsEnvInjectIfAny(run, logger, envVars);
     }

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectPasswordsMasker.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectPasswordsMasker.java
@@ -35,7 +35,7 @@ public class EnvInjectPasswordsMasker implements Serializable {
      */
     @Deprecated
     public void maskPasswordsIfAny(@Nonnull AbstractBuild run, @Nonnull EnvInjectLogger logger, @Nonnull Map<String, String> envVars) {
-        maskPasswordParameterssIfAny(run, envVars, logger);
+        maskPasswordParametersIfAny(run, envVars, logger);
     }
     
     /**
@@ -45,7 +45,7 @@ public class EnvInjectPasswordsMasker implements Serializable {
      * @param logger Logger
      * @since 2.1
      */
-    public void maskPasswordParameterssIfAny(@Nonnull Run<?, ?> run, @Nonnull Map<String, String> envVars, @Nonnull EnvInjectLogger logger) {
+    public void maskPasswordParametersIfAny(@Nonnull Run<?, ?> run, @Nonnull Map<String, String> envVars, @Nonnull EnvInjectLogger logger) {
         maskPasswordsJobParameterIfAny(run, logger, envVars);
         maskPasswordsEnvInjectIfAny(run, logger, envVars);
     }

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectVariableGetter.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectVariableGetter.java
@@ -31,9 +31,22 @@ public class EnvInjectVariableGetter {
 
     private static Logger LOG = Logger.getLogger(EnvInjectVariableGetter.class.getName());
 
-    @Nonnull
-    public Map<String, String> getJenkinsSystemVariables(boolean forceOnMaster) throws IOException, InterruptedException {
+    @Deprecated
+    public EnvInjectVariableGetter() {
+    }
 
+    /**
+     * @deprecated Use {@link #getJenkinsSystemEnvVars(boolean)}
+     */
+    @Nonnull
+    @Deprecated
+    public Map<String, String> getJenkinsSystemVariables(boolean forceOnMaster) throws IOException, InterruptedException {
+        return getJenkinsSystemEnvVars(forceOnMaster);
+    }
+    
+    //TODO: Move to Another utility class in EnvInject API 
+    @Nonnull
+    public static Map<String, String> getJenkinsSystemEnvVars(boolean forceOnMaster) throws IOException, InterruptedException {
         Map<String, String> result = new TreeMap<String, String>();
 
         final Computer computer;
@@ -72,18 +85,27 @@ public class EnvInjectVariableGetter {
     }
 
 
-    @SuppressWarnings("unchecked")
+    /**
+     * @deprecated Use {@link RunHelper#getBuildVariables(hudson.model.Run, hudson.EnvVars)}
+     */
     public Map<String, String> getBuildVariables(@Nonnull AbstractBuild build, @Nonnull EnvInjectLogger logger) throws EnvInjectException {
         return RunHelper.getBuildVariables(build, logger);
     }
 
+    /**
+     * @deprecated Use {@link RunHelper#getEnvInjectJobProperty(hudson.model.Run)}
+     */
     @CheckForNull
-    @SuppressWarnings("unchecked")
+    @Deprecated
     public EnvInjectJobProperty getEnvInjectJobProperty(@Nonnull AbstractBuild build) {
         return RunHelper.getEnvInjectJobProperty(build);
     }
 
+    /**
+     * @deprecated Use {@link RunHelper#getEnvVarsPreviousSteps(hudson.model.Run, org.jenkinsci.lib.envinject.EnvInjectLogger)}
+     */
     @Nonnull
+    @Deprecated
     public Map<String, String> getEnvVarsPreviousSteps(
             @Nonnull AbstractBuild build, @Nonnull EnvInjectLogger logger) 
             throws IOException, InterruptedException, EnvInjectException {

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectVariableGetter.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectVariableGetter.java
@@ -1,39 +1,32 @@
 package org.jenkinsci.plugins.envinject.service;
 
-import hudson.EnvVars;
+import hudson.RestrictedSince;
 import hudson.Util;
-import hudson.matrix.MatrixRun;
 import hudson.model.AbstractBuild;
 import hudson.model.Computer;
-import hudson.model.Environment;
-import hudson.model.EnvironmentContributor;
-import hudson.model.Executor;
 import hudson.model.Hudson.MasterComputer;
-import hudson.model.Job;
 import hudson.model.Node;
-import hudson.model.Run;
-import hudson.util.LogTaskListener;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 import org.jenkinsci.lib.envinject.EnvInjectLogger;
 import org.jenkinsci.plugins.envinject.EnvInjectJobProperty;
-import org.jenkinsci.plugins.envinject.EnvInjectJobPropertyInfo;
-import org.jenkinsci.plugins.envinject.EnvInjectPluginAction;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.envinject.util.RunHelper;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
+ * Utility class for retrieving environment variables.
  * @author Gregory Boissinot
  */
+@Restricted(NoExternalUse.class)
+@RestrictedSince("2.1")
 public class EnvInjectVariableGetter {
 
     private static Logger LOG = Logger.getLogger(EnvInjectVariableGetter.class.getName());
@@ -80,108 +73,20 @@ public class EnvInjectVariableGetter {
 
 
     @SuppressWarnings("unchecked")
-    public Map<String, String> getBuildVariables(@Nonnull Run<?, ?> run, @Nonnull EnvInjectLogger logger) throws EnvInjectException {
-        EnvVars result = new EnvVars();
-
-        //Add build process variables
-        result.putAll(run.getCharacteristicEnvVars());
-
-        try {
-            EnvVars envVars = new EnvVars();
-            for (EnvironmentContributor ec : EnvironmentContributor.all()) {
-                ec.buildEnvironmentFor(run, envVars, new LogTaskListener(LOG, Level.ALL));
-                result.putAll(envVars);
-            }
-            
-            // Handle JDK
-            RunHelper.getJDKVariables(run, logger.getListener(), result);
-        } catch (IOException ioe) {
-            throw new EnvInjectException(ioe);
-        } catch (InterruptedException ie) {
-            throw new EnvInjectException(ie);
-        }
-
-        Executor e = run.getExecutor();
-        if (e != null) {
-            result.put("EXECUTOR_NUMBER", String.valueOf(e.getNumber()));
-        }
-
-        String rootUrl = Jenkins.getActiveInstance().getRootUrl();
-        if (rootUrl != null) {
-            result.put("BUILD_URL", rootUrl + run.getUrl());
-            result.put("JOB_URL", rootUrl + run.getParent().getUrl());
-        }
-
-        //Add build variables such as parameters, plugins contributions, ...
-        RunHelper.getBuildVariables(run, result);
-
-        //Retrieve triggered cause
-        Map<String, String> triggerVariable = new BuildCauseRetriever().getTriggeredCause(run);
-        result.putAll(triggerVariable);
-
-        return result;
+    public Map<String, String> getBuildVariables(@Nonnull AbstractBuild build, @Nonnull EnvInjectLogger logger) throws EnvInjectException {
+        return RunHelper.getBuildVariables(build, logger);
     }
 
     @CheckForNull
     @SuppressWarnings("unchecked")
-    public EnvInjectJobProperty getEnvInjectJobProperty(@Nonnull Run<?, ?> build) {
-        if (build == null) {
-            throw new IllegalArgumentException("A build object must be set.");
-        }
-
-        final Job job;
-        if (build instanceof MatrixRun) {
-            job = ((MatrixRun) build).getParentBuild().getParent();
-        } else {
-            job = build.getParent();
-        }
-
-        EnvInjectJobProperty envInjectJobProperty = (EnvInjectJobProperty) job.getProperty(EnvInjectJobProperty.class);
-        if (envInjectJobProperty != null) {
-            EnvInjectJobPropertyInfo info = envInjectJobProperty.getInfo();
-            if (info != null && envInjectJobProperty.isOn()) {
-                return envInjectJobProperty;
-            }
-        }
-        return null;
+    public EnvInjectJobProperty getEnvInjectJobProperty(@Nonnull AbstractBuild build) {
+        return RunHelper.getEnvInjectJobProperty(build);
     }
 
     @Nonnull
     public Map<String, String> getEnvVarsPreviousSteps(
-            @Nonnull Run<?, ?> build, @Nonnull EnvInjectLogger logger) 
+            @Nonnull AbstractBuild build, @Nonnull EnvInjectLogger logger) 
             throws IOException, InterruptedException, EnvInjectException {
-        Map<String, String> result = new HashMap<String, String>();
-
-        // Env vars contributed by build wrappers; no replacement in Pipeline
-        if (build instanceof AbstractBuild) {
-            List<Environment> environmentList = ((AbstractBuild)build).getEnvironments();
-            if (environmentList != null) {
-                for (Environment e : environmentList) {
-                    if (e != null) {
-                        e.buildEnvVars(result);
-                    }
-                }
-            }
-        }
-
-        EnvInjectPluginAction envInjectAction = build.getAction(EnvInjectPluginAction.class);
-        if (envInjectAction != null) {
-            result.putAll(getCurrentInjectedEnvVars(envInjectAction));
-            //Add build variables with axis for a MatrixRun
-            if (build instanceof MatrixRun) {
-                result.putAll(((MatrixRun)build).getBuildVariables());
-            }
-        } else {
-            result.putAll(getJenkinsSystemVariables(false));
-            result.putAll(getBuildVariables(build, logger));
-        }
-        return result;
+        return RunHelper.getEnvVarsPreviousSteps(build, logger);
     }
-
-    @Nonnull
-    private Map<String, String> getCurrentInjectedEnvVars(@Nonnull EnvInjectPluginAction envInjectPluginAction) {
-        Map<String, String> envVars = envInjectPluginAction.getEnvMap();
-        return (envVars) == null ? new HashMap<String, String>() : envVars;
-    }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvironmentVariablesNodeLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvironmentVariablesNodeLoader.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.envinject.service;
 
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.RestrictedSince;
 import hudson.model.Node;
 import hudson.model.Run;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
@@ -19,13 +20,28 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 
+// TODO: Restrict?
 /**
  * @author Gregory Boissinot
  */
 public class EnvironmentVariablesNodeLoader implements Serializable {
 
+    @Deprecated
+    public EnvironmentVariablesNodeLoader() {
+    }
+
+    /**
+     * @deprecated Use {@link #gatherEnvVarsForNode(hudson.model.Run, hudson.model.Node, org.jenkinsci.lib.envinject.EnvInjectLogger)}
+     */
     @Nonnull
+    @Deprecated
     public Map<String, String> gatherEnvironmentVariablesNode(@Nonnull Run<?, ?> build, 
+            @CheckForNull Node buildNode, @Nonnull EnvInjectLogger logger) throws EnvInjectException {
+        return gatherEnvVarsForNode(build, buildNode, logger);
+    }
+    
+    @Nonnull
+    public static Map<String, String> gatherEnvVarsForNode(@Nonnull Run<?, ?> build, 
             @CheckForNull Node buildNode, @Nonnull EnvInjectLogger logger) throws EnvInjectException {
 
         logger.info("Loading node environment variables.");

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvironmentVariablesNodeLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvironmentVariablesNodeLoader.java
@@ -2,8 +2,8 @@ package org.jenkinsci.plugins.envinject.service;
 
 import hudson.EnvVars;
 import hudson.FilePath;
-import hudson.model.AbstractBuild;
 import hudson.model.Node;
+import hudson.model.Run;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
 import jenkins.security.MasterToSlaveCallable;
@@ -25,7 +25,7 @@ import jenkins.model.Jenkins;
 public class EnvironmentVariablesNodeLoader implements Serializable {
 
     @Nonnull
-    public Map<String, String> gatherEnvironmentVariablesNode(@Nonnull AbstractBuild build, 
+    public Map<String, String> gatherEnvironmentVariablesNode(@Nonnull Run<?, ?> build, 
             @CheckForNull Node buildNode, @Nonnull EnvInjectLogger logger) throws EnvInjectException {
 
         logger.info("Loading node environment variables.");

--- a/src/main/java/org/jenkinsci/plugins/envinject/util/RunHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/util/RunHelper.java
@@ -1,0 +1,96 @@
+package org.jenkinsci.plugins.envinject.util;
+
+import hudson.EnvVars;
+import hudson.model.AbstractBuild;
+import hudson.model.JDK;
+import hudson.model.Node;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+//TODO: Ideally it should be offered by the core
+/**
+ * This method contains abstraction layers for methods, which are available only in {@link AbstractBuild}.
+ * @author Oleg Nenashev
+ */
+@Restricted(NoExternalUse.class)
+public class RunHelper {
+    
+    /**
+     * Compatible version of {@link AbstractBuild#getSensitiveBuildVariables()}
+     * @param run Run
+     * @return List of sensitive variables
+     */
+    public static Set<String> getSensitiveBuildVariables(@Nonnull Run<?,? > run) {
+        if (run instanceof AbstractBuild) {
+            return ((AbstractBuild)run).getSensitiveBuildVariables();
+        }
+        
+        Set<String> s = new HashSet<String>();
+        ParametersAction parameters = run.getAction(ParametersAction.class);
+        if (parameters != null) {
+            for (ParameterValue p : parameters) {
+                if (p.isSensitive()) {
+                    s.add(p.getName());
+                }
+            }
+        }
+        
+        return s;
+    }
+    
+    /**
+     * Gets build variables.
+     * For {@link AbstractBuild} it invokes the standard method, 
+     * for other types it relies on {@link ParametersAction} only.
+     * @param run Run
+     * @param result Target collection, where the variables will be added
+     */
+    public static void getBuildVariables(@Nonnull Run<?, ?> run, EnvVars result) {
+        if (run instanceof AbstractBuild) {
+            Map buildVariables = ((AbstractBuild)run).getBuildVariables();
+            result.putAll(buildVariables);
+        }
+           
+        ParametersAction parameters = run.getAction(ParametersAction.class);
+        if (parameters!=null) {
+            // TODO: not sure if buildEnvironment is safe in this context (e.g. FileParameter)
+            for (ParameterValue p : parameters) {
+                p.buildEnvironment(run, result);
+            }
+        }
+    }
+    
+    /**
+     * Gets JDK variables.
+     * For {@link AbstractBuild} it invokes operation on the node to retrieve the data; 
+     * for other types it does nothing.
+     * @param run Run
+     * @param logger Logger
+     * @param result Target collection, where the variables will be added
+     * @throws IOException Operation failure
+     * @throws InterruptedException Operation has been interrupted
+     */
+    public static void getJDKVariables(@Nonnull Run<?, ?> run, TaskListener logger, EnvVars result) 
+            throws IOException, InterruptedException {
+        if (run instanceof AbstractBuild) {
+            AbstractBuild b = (AbstractBuild) run;
+            JDK jdk = b.getProject().getJDK();
+            if (jdk != null) {
+                Node node = b.getBuiltOn();
+                if (node != null) {
+                    jdk = jdk.forNode(node, logger);
+                }
+                jdk.buildEnvVars(result);
+            }
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/envinject/util/RunHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/util/RunHelper.java
@@ -210,7 +210,7 @@ public class RunHelper {
                 result.putAll(((MatrixRun)build).getBuildVariables());
             }
         } else {
-            result.putAll(new EnvInjectVariableGetter().getJenkinsSystemVariables(false));
+            result.putAll(EnvInjectVariableGetter.getJenkinsSystemEnvVars(false));
             result.putAll(getBuildVariables(build, logger));
         }
         return result;

--- a/src/main/java/org/jenkinsci/plugins/envinject/util/RunHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/util/RunHelper.java
@@ -1,18 +1,37 @@
 package org.jenkinsci.plugins.envinject.util;
 
 import hudson.EnvVars;
+import hudson.matrix.MatrixRun;
 import hudson.model.AbstractBuild;
+import hudson.model.Environment;
+import hudson.model.EnvironmentContributor;
+import hudson.model.Executor;
 import hudson.model.JDK;
+import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
+import org.jenkinsci.lib.envinject.EnvInjectException;
+import org.jenkinsci.lib.envinject.EnvInjectLogger;
+import org.jenkinsci.plugins.envinject.EnvInjectJobProperty;
+import org.jenkinsci.plugins.envinject.EnvInjectJobPropertyInfo;
+import org.jenkinsci.plugins.envinject.EnvInjectPluginAction;
+import org.jenkinsci.plugins.envinject.service.BuildCauseRetriever;
+import org.jenkinsci.plugins.envinject.service.EnvInjectVariableGetter;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -23,6 +42,8 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  */
 @Restricted(NoExternalUse.class)
 public class RunHelper {
+    
+    private static final Logger LOGGER = Logger.getLogger(RunHelper.class.getName());
     
     /**
      * Compatible version of {@link AbstractBuild#getSensitiveBuildVariables()}
@@ -92,5 +113,112 @@ public class RunHelper {
                 jdk.buildEnvVars(result);
             }
         }
+    }
+    
+    // Moved from EnvInjectVariableGetter
+    
+    @SuppressWarnings("unchecked")
+    public static Map<String, String> getBuildVariables(@Nonnull Run<?, ?> run, @Nonnull EnvInjectLogger logger) throws EnvInjectException {
+        EnvVars result = new EnvVars();
+
+        //Add build process variables
+        result.putAll(run.getCharacteristicEnvVars());
+
+        try {
+            EnvVars envVars = new EnvVars();
+            for (EnvironmentContributor ec : EnvironmentContributor.all()) {
+                ec.buildEnvironmentFor(run, envVars, new LogTaskListener(LOGGER, Level.ALL));
+                result.putAll(envVars);
+            }
+            
+            // Handle JDK
+            RunHelper.getJDKVariables(run, logger.getListener(), result);
+        } catch (IOException ioe) {
+            throw new EnvInjectException(ioe);
+        } catch (InterruptedException ie) {
+            throw new EnvInjectException(ie);
+        }
+
+        Executor e = run.getExecutor();
+        if (e != null) {
+            result.put("EXECUTOR_NUMBER", String.valueOf(e.getNumber()));
+        }
+
+        String rootUrl = Jenkins.getActiveInstance().getRootUrl();
+        if (rootUrl != null) {
+            result.put("BUILD_URL", rootUrl + run.getUrl());
+            result.put("JOB_URL", rootUrl + run.getParent().getUrl());
+        }
+
+        //Add build variables such as parameters, plugins contributions, ...
+        RunHelper.getBuildVariables(run, result);
+
+        //Retrieve triggered cause
+        Map<String, String> triggerVariable = new BuildCauseRetriever().getTriggeredCause(run);
+        result.putAll(triggerVariable);
+
+        return result;
+    }
+
+    @CheckForNull
+    @SuppressWarnings("unchecked")
+    public static EnvInjectJobProperty getEnvInjectJobProperty(@Nonnull Run<?, ?> build) {
+        if (build == null) {
+            throw new IllegalArgumentException("A build object must be set.");
+        }
+
+        final Job job;
+        if (build instanceof MatrixRun) {
+            job = ((MatrixRun) build).getParentBuild().getParent();
+        } else {
+            job = build.getParent();
+        }
+
+        EnvInjectJobProperty envInjectJobProperty = (EnvInjectJobProperty) job.getProperty(EnvInjectJobProperty.class);
+        if (envInjectJobProperty != null) {
+            EnvInjectJobPropertyInfo info = envInjectJobProperty.getInfo();
+            if (info != null && envInjectJobProperty.isOn()) {
+                return envInjectJobProperty;
+            }
+        }
+        return null;
+    }
+
+    @Nonnull
+    public static Map<String, String> getEnvVarsPreviousSteps(
+            @Nonnull Run<?, ?> build, @Nonnull EnvInjectLogger logger) 
+            throws IOException, InterruptedException, EnvInjectException {
+        Map<String, String> result = new HashMap<String, String>();
+
+        // Env vars contributed by build wrappers; no replacement in Pipeline
+        if (build instanceof AbstractBuild) {
+            List<Environment> environmentList = ((AbstractBuild)build).getEnvironments();
+            if (environmentList != null) {
+                for (Environment e : environmentList) {
+                    if (e != null) {
+                        e.buildEnvVars(result);
+                    }
+                }
+            }
+        }
+
+        EnvInjectPluginAction envInjectAction = build.getAction(EnvInjectPluginAction.class);
+        if (envInjectAction != null) {
+            result.putAll(getCurrentInjectedEnvVars(envInjectAction));
+            //Add build variables with axis for a MatrixRun
+            if (build instanceof MatrixRun) {
+                result.putAll(((MatrixRun)build).getBuildVariables());
+            }
+        } else {
+            result.putAll(new EnvInjectVariableGetter().getJenkinsSystemVariables(false));
+            result.putAll(getBuildVariables(build, logger));
+        }
+        return result;
+    }
+
+    @Nonnull
+    private static Map<String, String> getCurrentInjectedEnvVars(@Nonnull EnvInjectPluginAction envInjectPluginAction) {
+        Map<String, String> envVars = envInjectPluginAction.getEnvMap();
+        return (envVars) == null ? new HashMap<String, String>() : envVars;
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/envinject/BuildCauseRetrieverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/BuildCauseRetrieverTest.java
@@ -14,10 +14,10 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import static com.google.common.base.Joiner.on;
 import static hudson.model.Result.SUCCESS;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.jenkinsci.plugins.envinject.matchers.WithEnvInjectActionMatchers.withCause;
 import static org.jenkinsci.plugins.envinject.matchers.WithEnvInjectActionMatchers.withCausesIsTrue;
+import static org.junit.Assert.assertThat;
 
 /**
  * @author Gregory Boissinot

--- a/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectBuildWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectBuildWrapperTest.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.envinject;
 
 import static com.google.common.collect.ImmutableMap.of;
 import static hudson.Util.replaceMacro;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.jenkinsci.plugins.envinject.matchers.WithEnvInjectActionMatchers.map;
@@ -28,10 +27,10 @@ import org.jvnet.hudson.test.SingleFileSCM;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 
 import jenkins.model.Jenkins;
-import static org.hamcrest.Matchers.containsString;
 import org.jenkinsci.plugins.envinject.util.TestUtils;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.scriptsecurity.scripts.UnapprovedUsageException;
+import static org.junit.Assert.assertThat;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 
 public class EnvInjectBuildWrapperTest {

--- a/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectEvaluatedGroovyScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectEvaluatedGroovyScriptTest.java
@@ -31,9 +31,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import static org.hamcrest.Matchers.containsString;
 
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
-import static org.hamcrest.core.StringContains.containsString;
 import org.jenkinsci.plugins.envinject.util.TestUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;

--- a/src/test/java/org/jenkinsci/plugins/envinject/sevice/EnvInjectVariableGetterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/sevice/EnvInjectVariableGetterTest.java
@@ -4,12 +4,12 @@ import hudson.matrix.MatrixRun;
 import hudson.model.AbstractBuild;
 import org.jenkinsci.lib.envinject.EnvInjectLogger;
 import org.jenkinsci.plugins.envinject.EnvInjectPluginAction;
-import org.jenkinsci.plugins.envinject.service.EnvInjectVariableGetter;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.jenkinsci.plugins.envinject.util.RunHelper;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -20,13 +20,10 @@ import static org.mockito.Mockito.when;
  */
 public class EnvInjectVariableGetterTest {
 
-    private EnvInjectVariableGetter variableGetter;
-
     private AbstractBuild build;
 
     @Before
     public void setUp() {
-        variableGetter = new EnvInjectVariableGetter();
         build = mock(AbstractBuild.class);
     }
 
@@ -48,7 +45,7 @@ public class EnvInjectVariableGetterTest {
     public void getEnvVarsPreviousStepsWithEnvInjectAction() throws Exception {
         EnvInjectPluginAction envInjectPluginAction = new EnvInjectPluginAction(build, envVarsSample1);
         when(build.getAction(EnvInjectPluginAction.class)).thenReturn(envInjectPluginAction);
-        Map<String, String> envVars = variableGetter.getEnvVarsPreviousSteps(build, mock(EnvInjectLogger.class));
+        Map<String, String> envVars = RunHelper.getEnvVarsPreviousSteps(build, mock(EnvInjectLogger.class));
         assertTrue(sameMap(envVarsSample1, envVars));
     }
 
@@ -58,7 +55,7 @@ public class EnvInjectVariableGetterTest {
         EnvInjectPluginAction envInjectPluginAction = new EnvInjectPluginAction(build, envVarsSample1);
         when(build.getAction(EnvInjectPluginAction.class)).thenReturn(envInjectPluginAction);
         when(build.getBuildVariables()).thenReturn(buildEnvVarsSample1);
-        Map<String, String> resultEnvVars = variableGetter.getEnvVarsPreviousSteps(build, mock(EnvInjectLogger.class));
+        Map<String, String> resultEnvVars = RunHelper.getEnvVarsPreviousSteps(build, mock(EnvInjectLogger.class));
         Map<String, String> expectedEnvVars = new HashMap<String, String>();
         expectedEnvVars.putAll(envVarsSample1);
         expectedEnvVars.putAll(buildEnvVarsSample1);


### PR DESCRIPTION
The change streamlines the handling logic of non-AbstractProject job types. Some use-cases in Pipeline may start working.

* Update Core dependency to 1.625 in order to pick the new `Files` API
* [JENKINS-43845](https://issues.jenkins-ci.org/browse/JENKINS-43845) - Use EnvInject API Plugin
* [JENKINS-43535](https://issues.jenkins-ci.org/browse/JENKINS-43535) - Make API compatible with non-AbstractProject types
* [JENKINS-43536](https://issues.jenkins-ci.org/browse/JENKINS-43536) - Cleanup AbstractProject/AbstractBuild usages in the plugin

Upstream PRs:
* https://github.com/jenkinsci/envinject-lib/pull/8
* https://github.com/jenkinsci/envinject-api-plugin/pull/1



@reviewbybees 

