### PR TITLE
[JENKINS-45056] - Update to EnvInject API bundled as a plugin + pick new EnvInject Lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>envinject-api</artifactId>
-            <version>1.0</version>
+            <version>1.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This issue definitely belongs to my hall of shame. I have not changed the packaging type in EnvInject API when I was releasing 1.0

* [JENKINS-45056](https://issues.jenkins-ci.org/browse/JENKINS-45056) - Fix issue with the incorrect plugin packaging in 1.0 due to the release flow issue.
* [JENKINS-45055](https://issues.jenkins-ci.org/browse/JENKINS-45055) - Update EnvInject Lib from 1.25 to 1.26 in order to pick FindBugs fixes ([changelog](https://github.com/jenkinsci/envinject-lib/blob/master/CHANGELOG.md#126)).

Diffs

* EnvInject Lib Diff: jenkinsci/envinject-lib@envinject-lib-1.25...envinject-lib-1.26
* EnvInject API Diff: https://github.com/jenkinsci/envinject-api-plugin/compare/envinject-api-1.0...envinject-api-1.2

@reviewbybees 

