### PR TITLE
[JENKINS-32428] Escape xml and json outputs in REST API - fix 2 (#120)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectVarList.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectVarList.java
@@ -140,7 +140,7 @@ public class EnvInjectVarList implements Serializable {
     }
 
     private String escapeJson(String json) {
-        return json.replace("\"", "\\\"").replace("\\", "\\\\");
+        return json.replace("\\", "\\\\").replace("\"", "\\\"");
     }
     
     //TODO: Throw errors in responses?


### PR DESCRIPTION
I added the replaces in wrong order at #120.
`"C:\Program Files\Java\jre1.8.0_131\bin"` got escaped with `\\"C:\\Program Files\\Java\\jre1.8.0_131\\bin\\"` which isn't valid json. The correct escaped string is `\"C:\\Program Files\\Java\\jre1.8.0_131\\bin\"`

@oleg-nenashev ping