### PR TITLE
Add compatibility notice for JENKINS-47364 and JENKINS-47370

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,9 +78,10 @@
               Incompatible changes:
                 1.93 - Fix of JENKINS-31573 changed the property file parsing approach. 
                      Now it follows the Java property file standard.
-                2.0: - Security fixes (SECURITY-256) 
+                2.0: - Security fixes (SECURITY-256)
+                2.1.4 - JENKINS-47364 and JENKINS-47370, they still need to be investigated
             -->
-            <compatibleSinceVersion>2.0</compatibleSinceVersion>
+            <compatibleSinceVersion>2.1.4</compatibleSinceVersion>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
Instead of blacklisting of the plugin now, I decided to add a compatibility notice for now while I investigate the issue and create test cases for the reported regressions. [Wiki](https://wiki.jenkins.io/display/JENKINS/EnvInject+Plugin) is explicit enough of the notice reasons.

@nfalco79 @dwnusbaum