### PR TITLE
Adding stop build support for env-inject groovy script

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectListener.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectListener.java
@@ -53,6 +53,10 @@ public class EnvInjectListener extends RunListener<Run> implements Serializable 
             } catch (Run.RunnerAbortedException rre) {
                 logger.info("Fail the build.");
                 throw new Run.RunnerAbortedException();
+            } catch (EnvInjectStopBuildException stopException) {
+                logger.info("Stopping build with result " + stopException.getResult() + ": " + stopException.getLocalizedMessage());
+                build.getExecutor().interrupt(stopException.getResult());
+                return null;
             } catch (EnvInjectException e) {
                 e.printStackTrace(listener.error("SEVERE ERROR occurs"));
                 throw new Run.RunnerAbortedException();

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectStopBuildException.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectStopBuildException.java
@@ -1,0 +1,24 @@
+package org.jenkinsci.plugins.envinject;
+
+import hudson.model.Result;
+import org.jenkinsci.lib.envinject.EnvInjectException;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Signals the plugin to stop the build and set the build result as specified,
+ * as opposed to Failure in the case of a RuntimeException
+ */
+public class EnvInjectStopBuildException extends EnvInjectException {
+
+    private final Result result;
+
+    public EnvInjectStopBuildException(@Nonnull String s, @Nonnull Result result) {
+        super(s);
+        this.result = result;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectEnvVars.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectEnvVars.java
@@ -16,6 +16,7 @@ import jenkins.model.Jenkins;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 import org.jenkinsci.lib.envinject.EnvInjectLogger;
+import org.jenkinsci.plugins.envinject.EnvInjectStopBuildException;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
 
@@ -228,6 +229,8 @@ public class EnvInjectEnvVars implements Serializable {
         final Object groovyResult;
         try {
             groovyResult = script.evaluate(jenkins.getPluginManager().uberClassLoader, binding);
+        } catch (EnvInjectStopBuildException eStop) {
+            throw eStop; //do not wrap
         } catch (Exception e) {
             throw new EnvInjectException("Failed to evaluate the script", e);
         }

--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectJobPropertyInfo/help-secureGroovyScript.html
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectJobPropertyInfo/help-secureGroovyScript.html
@@ -49,4 +49,24 @@
             return null;
           }
         </code></pre>
+
+    <h3>Stopping the build</h3>
+    <p>
+        It is possible to stop the build if the groovy script determines that execution should not proceed.
+        An example scenario would be a job that checks some upstream precondition in this step
+        and sets up the environment if the condition is met, but stops the build if not.
+    </p>
+    <p>
+        Throwing any RuntimeException (eg InterruptedException) will cause the build to abort and get marked as Failure.
+        Throwing EnvInjectStopBuildException allows the result to be specified, and hides the stacktrace.
+    </p>
+
+    <h3>Example</h3>
+    <pre>
+        <code>
+            if (somePrecondition) {
+                throw new org.jenkinsci.plugins.envinject.EnvInjectStopBuildException("It's not time to run this job", hudson.model.Result.UNSTABLE)
+            }
+        </code>
+    </pre>
 </div>


### PR DESCRIPTION
The need to abort the build in the groovy script is something I stumble upon a lot.  It's easy enough (throw), but results in a build failure.  I'd like to disambiguate a truly failed (red) build from a "I decided not to run this build" by changing its build status.

Note: I couldn't get the test to work exactly like real Jenkins - the test interrupts the job but it runs anyway, while in real life the job does not continue.  I don't know why that is.

Let me know if there are better ways to do all this... 