### PR TITLE
Fix type currentBuid to currentBuild

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectJobPropertyInfo/help-secureGroovyScript.html
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectJobPropertyInfo/help-secureGroovyScript.html
@@ -15,7 +15,7 @@
     <dl>
       <dt>currentJob</dt>
       <dd>Current <a href="http://javadoc.jenkins-ci.org/hudson/model/Job.html">hudson.model.Job</a> instance.</dd>
-      <dt>currentBuid</dt>
+      <dt>currentBuild</dt>
       <dd>Current <a href="http://javadoc.jenkins-ci.org/hudson/model/Run.html">hudson.model.Run</a> instance.</dd>
       <dt>currentListener</dt>
       <dd>Current <a href="http://javadoc.jenkins.io/hudson/model/TaskListener.html">hudson.model.TaskListener</a> instance,


### PR DESCRIPTION
Fixed a nasty type in the help section (for all of those who copy the variable names).