### PR TITLE
Use safe reflection for Java 11

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectComputerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectComputerListener.java
@@ -19,8 +19,6 @@ import org.jenkinsci.plugins.envinject.service.EnvInjectMasterEnvVarsSetter;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.CheckForNull;

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
@@ -45,6 +45,8 @@ public class EnvInjectMasterEnvVarsSetter extends MasterToSlaveCallable<Void, En
                 enVars.remove("MAVEN_OPTS");
             }
             
+            // TODO: this is not thread safe, but making it so requires some thought.
+            // See https://issues.jenkins-ci.org/browse/JENKINS-53724
             EnvVars.masterEnvVars.clear();
             EnvVars.masterEnvVars.putAll(enVars); 
         } catch (IllegalAccessException | NoSuchFieldException | NoSuchMethodException | InvocationTargetException exception) {

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
@@ -3,12 +3,15 @@ package org.jenkinsci.plugins.envinject.service;
 import hudson.EnvVars;
 import hudson.Main;
 import hudson.Platform;
+import hudson.util.VersionNumber;
 import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
 
 /**
  * @author Gregory Boissinot
@@ -16,6 +19,11 @@ import javax.annotation.Nonnull;
 public class EnvInjectMasterEnvVarsSetter extends MasterToSlaveCallable<Void, EnvInjectException> {
 
     private @Nonnull EnvVars enVars;
+    
+    // TODO: this may not be the version of core that gets the fix allowing us to
+    // use safe reflection to set the Platform. The exact version needs to be updated 
+    // after that version is released.
+    private static VersionNumber jenkinsVersionWithSetPlatform = new VersionNumber("2.139");
 
     public EnvInjectMasterEnvVarsSetter(@Nonnull EnvVars enVars) {
         this.enVars = enVars;
@@ -24,22 +32,23 @@ public class EnvInjectMasterEnvVarsSetter extends MasterToSlaveCallable<Void, En
     @Override
     public Void call() throws EnvInjectException {
         try {
-            Field platformField = EnvVars.class.getDeclaredField("platform");
-            platformField.setAccessible(true);
-            platformField.set(enVars, Platform.current());
+            if (Jenkins.getVersion().isOlderThan(jenkinsVersionWithSetPlatform)) {
+                Field platformField = EnvVars.class.getDeclaredField("platform");
+
+                platformField.setAccessible(true);
+                platformField.set(enVars, Platform.current());                
+            } else {
+                Method method = EnvVars.class.getDeclaredMethod("setPlatform", Platform.class);
+                method.invoke(enVars, Platform.current());
+            }
             if (Main.isUnitTest || Main.isDevelopmentMode) {
                 enVars.remove("MAVEN_OPTS");
             }
-            Field masterEnvVarsFiled = EnvVars.class.getDeclaredField("masterEnvVars");
-            masterEnvVarsFiled.setAccessible(true);
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersField.setAccessible(true);
-            modifiersField.setInt(masterEnvVarsFiled, masterEnvVarsFiled.getModifiers() & ~Modifier.FINAL);
-            masterEnvVarsFiled.set(null, enVars);
-        } catch (IllegalAccessException iae) {
-            throw new EnvInjectException(iae);
-        } catch (NoSuchFieldException nsfe) {
-            throw new EnvInjectException(nsfe);
+            
+            EnvVars.masterEnvVars.clear();
+            EnvVars.masterEnvVars.putAll(enVars); 
+        } catch (IllegalAccessException | NoSuchFieldException | NoSuchMethodException | InvocationTargetException exception) {
+            throw new EnvInjectException(exception);
         }
 
         return null;


### PR DESCRIPTION
This PR removes unsafe reflection to remove warnings on the build agent when the plugin is used.

Please note that it's dependent upon first merging https://github.com/jenkinsci/jenkins/pull/3639, and the version number in this PR needs to be updated once the version is known (see TODO comment in the code)