### PR TITLE
[JENKINS-39403] - Automatically escape single backslashes in the properties loader

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesLoader.java
@@ -71,7 +71,7 @@ public class PropertiesLoader implements Serializable {
 
         // Replace single backslashes with double ones so they won't be removed by Property.load()
         String escapedContent = content;
-        escapedContent = escapedContent.replaceAll("(?<=[^\\\\])\\\\(?=[^n])(?=[^\\\\])(?=[^\n])", "\\\\\\\\");
+        escapedContent = escapedContent.replaceAll("(?<=[^\\\\])\\\\(?![n|:|*|?|\"|<|>|\\||\\/])(?![\\\\])(?![\n])", "\\\\\\\\");
         Map<String, String> result = new LinkedHashMap<String, String>();
         StringReader stringReader = new StringReader(escapedContent);
         Properties properties = new Properties();

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesLoader.java
@@ -68,8 +68,12 @@ public class PropertiesLoader implements Serializable {
     @Nonnull
     private Map<String, String> getVars(@Nonnull String content, @Nonnull Map<String, String> currentEnvVars) 
             throws EnvInjectException {
+
+        // Replace single backslashes with double ones so they won't be removed by Property.load()
+        String escapedContent = content;
+        escapedContent = escapedContent.replaceAll("(?<=[^\\\\])\\\\(?=[^n])(?=[^\\\\])(?=[^\n])", "\\\\\\\\");
         Map<String, String> result = new LinkedHashMap<String, String>();
-        StringReader stringReader = new StringReader(content);
+        StringReader stringReader = new StringReader(escapedContent);
         Properties properties = new Properties();
 
         try {

--- a/src/test/java/org/jenkinsci/plugins/envinject/sevice/PropertiesLoaderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/sevice/PropertiesLoaderTest.java
@@ -148,7 +148,7 @@ public class PropertiesLoaderTest {
     }
 
     private void checkWithVarsToResolve(boolean fromFile) throws Exception {
-        String content = "KEY1 =${VAR1_TO_RESOLVE}\nKEY2=https://github.com\nKEY3=${VAR3_TO_RESOLVE}\\\\otherContent";
+        String content = "KEY1 =${VAR1_TO_RESOLVE}\nKEY2=https\\://github.com\nKEY3=${VAR3_TO_RESOLVE}\\\\otherContent";
         Map<String, String> currentEnvVars = new HashMap<String, String>();
         currentEnvVars.put("VAR1_TO_RESOLVE", "NEW_VALUE1 ");
         currentEnvVars.put("VAR3_TO_RESOLVE", "C:\\Bench");

--- a/src/test/java/org/jenkinsci/plugins/envinject/sevice/PropertiesLoaderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/sevice/PropertiesLoaderTest.java
@@ -125,7 +125,7 @@ public class PropertiesLoaderTest {
 
     private void checkWithNewlineInValues(boolean fromFile) throws Exception {
         // Create properties file containing backslash-escaped newlines
-        String content = "KEY1=line1\\nline2\nKEY2= line3 \\n\\\n line4 \nKEY3=line5\\\n\\\nline6\nKEY4=line7\\\nline8\\n\\nline9";
+        String content = "KEY1=line1\\nline2\nKEY2= line3 \\n\\\nline4 \nKEY3=line5\\\n\\\nline6\nKEY4=line7\\\nline8\\n\\nline9";
         Map<String, String> gatherVars = gatherEnvVars(fromFile, content, new HashMap<String, String>());
         assertNotNull(gatherVars);
         assertEquals(4, gatherVars.size());
@@ -148,7 +148,7 @@ public class PropertiesLoaderTest {
     }
 
     private void checkWithVarsToResolve(boolean fromFile) throws Exception {
-        String content = "KEY1 =${VAR1_TO_RESOLVE}\nKEY2=https\\://github.com\nKEY3=${VAR3_TO_RESOLVE}\\\\otherContent";
+        String content = "KEY1 =${VAR1_TO_RESOLVE}\nKEY2=https://github.com\nKEY3=${VAR3_TO_RESOLVE}\\\\otherContent";
         Map<String, String> currentEnvVars = new HashMap<String, String>();
         currentEnvVars.put("VAR1_TO_RESOLVE", "NEW_VALUE1 ");
         currentEnvVars.put("VAR3_TO_RESOLVE", "C:\\Bench");
@@ -159,6 +159,26 @@ public class PropertiesLoaderTest {
         assertEquals("NEW_VALUE1", gatherVars.get("KEY1"));
         assertEquals("https://github.com", gatherVars.get("KEY2"));
         assertEquals("C:\\Bench\\otherContent", gatherVars.get("KEY3"));
+    }
+
+    //JENKINS-39403
+    @Test
+    public void fileWithBackSlashes() throws Exception {
+        checkWithBackSlashes(true);
+    }
+
+    @Test
+    public void contentWithBackSlashes() throws Exception {
+        checkWithBackSlashes(false);
+    }
+
+    private void checkWithBackSlashes(boolean fromFile) throws Exception {
+        String content = "KEY1=Test\\Path\\Variable";
+        Map<String, String> gatherVars = gatherEnvVars(fromFile, content, new HashMap<String, String>());
+        assertNotNull(gatherVars);
+        assertEquals(1, gatherVars.size());
+
+        assertEquals("Test\\Path\\Variable", gatherVars.get("KEY1"));
     }
 
     private Map<String, String> gatherEnvVars(boolean fromFile, String content2Load, Map<String, String> currentEnvVars) throws Exception {


### PR DESCRIPTION
Windows paths can now be used without the need to change all properties files to have the escaped \\ character

There is some funkyness that I had to regex for inside of the code in order to have /n work as intended. I just ignored all /n and //n that happens to ensure that the previous behavior is not touched. Maybe we should change that eventually but I wanted to focus my efforts on arbitrary / characters