### PR TITLE
[JENKINS-56449] - Add support for global config via configuration-as-code plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>1.7</version>
+            <version>1.23</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <ivy.plugin.version>1.21</ivy.plugin.version>
         <mockito.version>1.10.19</mockito.version>
-        <jenkins.version>1.625.3</jenkins.version>
+        <jenkins.version>2.14</jenkins.version>
         <java.level>7</java.level>
         <!-- Remove once JENKINS-45055 is fixed -->
         <findbugs.failOnError>false</findbugs.failOnError>
@@ -156,6 +156,12 @@
             <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
             <artifactId>icon-shim</artifactId>
             <version>2.0.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <version>1.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration.java
@@ -35,6 +35,7 @@ import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.lib.envinject.EnvInjectException;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -47,6 +48,7 @@ import org.kohsuke.stapler.StaplerRequest;
  * @since 1.92
  */
 @Extension
+@Symbol("envinject")
 public class EnvInjectPluginConfiguration extends GlobalConfiguration {
     
     private static final EnvInjectPluginConfiguration DEFAULT = 

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration.java
@@ -48,7 +48,7 @@ import org.kohsuke.stapler.StaplerRequest;
  * @since 1.92
  */
 @Extension
-@Symbol("envinject")
+@Symbol("envInject")
 public class EnvInjectPluginConfiguration extends GlobalConfiguration {
     
     private static final EnvInjectPluginConfiguration DEFAULT = 

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration.java
@@ -64,8 +64,6 @@ public class EnvInjectPluginConfiguration extends GlobalConfiguration {
      */
     private boolean enableLoadingFromMaster;
 
-    @Restricted(NoExternalUse.class)
-    @RestrictedSince("2.0")
     @DataBoundConstructor
     public EnvInjectPluginConfiguration() {
         load();

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectPluginConfiguration.java
@@ -38,6 +38,7 @@ import org.jenkinsci.lib.envinject.EnvInjectException;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
 /**
@@ -65,6 +66,7 @@ public class EnvInjectPluginConfiguration extends GlobalConfiguration {
 
     @Restricted(NoExternalUse.class)
     @RestrictedSince("2.0")
+    @DataBoundConstructor
     public EnvInjectPluginConfiguration() {
         load();
     }
@@ -96,9 +98,15 @@ public class EnvInjectPluginConfiguration extends GlobalConfiguration {
         return hideInjectedVars;
     }
 
+    @DataBoundSetter
+    public void setHideInjectedVars(boolean hideInjectedVars) { this.hideInjectedVars = hideInjectedVars; }
+
     public boolean isEnablePermissions() {
         return enablePermissions;
     }
+
+    @DataBoundSetter
+    public void setEnablePermissions(boolean enabledPermissions) { this.enablePermissions = enabledPermissions; }
 
     /**
      * Check if the instance supports loading of scripts and property files from the master.
@@ -110,7 +118,10 @@ public class EnvInjectPluginConfiguration extends GlobalConfiguration {
     public boolean isEnableLoadingFromMaster() {
         return enableLoadingFromMaster;
     }
-    
+
+    @DataBoundSetter
+    public void setEnableLoadingFromMaster(boolean enableLoadingFromMaster) { this.enableLoadingFromMaster = enableLoadingFromMaster; }
+
     /**
      * Gets the default configuration of {@link EnvInjectPlugin}
      * @return Default configuration

--- a/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectPluginConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/EnvInjectPluginConfigurationTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import io.jenkins.plugins.casc.ConfigurationAsCode;
 
 /**
  * Tests for {@link EnvInjectPluginConfiguration}.
@@ -45,5 +46,15 @@ public class EnvInjectPluginConfigurationTest {
                 config.isHideInjectedVars(), reloaded.isHideInjectedVars());
         assertEquals("Value of enableLoadingFromMaster differs after the reload",
                 config.isEnableLoadingFromMaster(), reloaded.isEnableLoadingFromMaster());
+    }
+
+    @Test
+    public void testConfigAsCode() throws Exception {
+        ConfigurationAsCode.get().configure(EnvInjectPluginConfigurationTest.class.getResource("configuration-as-code.yml").toString());
+
+        final EnvInjectPluginConfiguration config = EnvInjectPluginConfiguration.getInstance();
+        assertTrue(config.isHideInjectedVars());
+        assertTrue(config.isEnablePermissions());
+        assertTrue(config.isEnableLoadingFromMaster());
     }
 }

--- a/src/test/resources/org/jenkinsci/plugins/envinject/configuration-as-code.yml
+++ b/src/test/resources/org/jenkinsci/plugins/envinject/configuration-as-code.yml
@@ -1,0 +1,6 @@
+---
+security:
+  envInjectPluginConfiguration:
+    hideInjectedVars: true
+    enablePermissions: true
+    enableLoadingFromMaster: true

--- a/src/test/resources/org/jenkinsci/plugins/envinject/configuration-as-code.yml
+++ b/src/test/resources/org/jenkinsci/plugins/envinject/configuration-as-code.yml
@@ -1,6 +1,7 @@
 ---
 security:
-  envInjectPluginConfiguration:
+  envinject:
     hideInjectedVars: true
     enablePermissions: true
+    # Bad idea, see the security advisories
     enableLoadingFromMaster: true


### PR DESCRIPTION
[JENKINS-56449](https://issues.jenkins-ci.org/browse/JENKINS-56449)

Based on https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/PLUGINS.md, adds support for defining EnvInject plugin global configuration within the configuration-as-code plugin.

