### PR TITLE
Update Jenkins core dependency to 2.138.4 + plugin POM facelift

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.37</version>
+        <version>3.47</version>
         <relativePath />
     </parent>
 
@@ -56,11 +56,18 @@
 
     <properties>
         <ivy.plugin.version>1.21</ivy.plugin.version>
-        <mockito.version>1.10.19</mockito.version>
-        <jenkins.version>1.625.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.138.4</jenkins.version>
+        <java.level>8</java.level>
         <!-- Remove once JENKINS-45055 is fixed -->
-        <findbugs.failOnError>false</findbugs.failOnError>
+        <spotbugs.failOnError>false</spotbugs.failOnError>
+        <!-- 
+          Incompatible changes:
+            1.93 - Fix of JENKINS-31573 changed the property file parsing approach. 
+                 Now it follows the Java property file standard.
+            2.0: - Security fixes (SECURITY-256)
+            2.1.4 - JENKINS-47364 and JENKINS-47370, they still need to be investigated
+        -->
+        <hpi.compatibleSinceVersion>2.1.4</hpi.compatibleSinceVersion>
     </properties>
 
     <scm>
@@ -69,31 +76,11 @@
         <tag>HEAD</tag>
     </scm>
 
-    <build>
-      <plugins>
-        <plugin>
-          <groupId>org.jenkins-ci.tools</groupId>
-          <artifactId>maven-hpi-plugin</artifactId>
-          <extensions>true</extensions>
-          <configuration>
-            <!-- 
-              Incompatible changes:
-                1.93 - Fix of JENKINS-31573 changed the property file parsing approach. 
-                     Now it follows the Java property file standard.
-                2.0: - Security fixes (SECURITY-256)
-                2.1.4 - JENKINS-47364 and JENKINS-47370, they still need to be investigated
-            -->
-            <compatibleSinceVersion>2.1.4</compatibleSinceVersion>
-          </configuration>
-        </plugin>
-      </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>envinject-api</artifactId>
-            <version>1.3</version>
+            <version>1.6</version>
         </dependency>
 
         <dependency>
@@ -125,7 +112,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         
@@ -149,13 +135,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-auth</artifactId>
-            <version>1.7</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency> <!-- TODO pending matrix-auth 2.0 -->
-            <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
-            <artifactId>icon-shim</artifactId>
-            <version>2.0.3</version>
+            <version>2.4.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
I would like to apply some patches and to ensure that the new version builds with Java 11