### PR TITLE
Fix anonymous class serialization warning in EnvInjectComputerListener 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectComputerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectComputerListener.java
@@ -96,11 +96,7 @@ public class EnvInjectComputerListener extends ComputerListener implements Seria
         
         //Get env vars for the current node
         Map<String, String> nodeEnvVars = nodePath.act(
-                new MasterToSlaveCallable<Map<String, String>, IOException>() {
-                    public Map<String, String> call() throws IOException {
-                        return EnvVars.masterEnvVars;
-                    }
-                });
+                new GetMasterEnvVars());
 
         // -- Process slave properties
         boolean unsetSystemVariables = false;

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectComputerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectComputerListener.java
@@ -11,10 +11,10 @@ import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.NodePropertyDescriptor;
 import hudson.util.DescribableList;
-import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 import org.jenkinsci.lib.envinject.EnvInjectLogger;
 import org.jenkinsci.plugins.envinject.service.EnvInjectEnvVars;
+import org.jenkinsci.plugins.envinject.service.EnvInjectMasterEnvVarsRetriever;
 import org.jenkinsci.plugins.envinject.service.EnvInjectMasterEnvVarsSetter;
 
 import java.io.IOException;
@@ -33,14 +33,11 @@ import jenkins.model.Jenkins;
 @Extension
 public class EnvInjectComputerListener extends ComputerListener implements Serializable {
 
-
     private EnvVars getNewMasterEnvironmentVariables(@Nonnull Computer c, 
             @Nonnull FilePath nodePath, @Nonnull TaskListener listener) throws EnvInjectException, IOException, InterruptedException {
 
         //Get env vars for the current node
-        Map<String, String> nodeEnvVars = nodePath.act(
-                new GetMasterEnvVars());
-
+        Map<String, String> nodeEnvVars = nodePath.act(new EnvInjectMasterEnvVarsRetriever());
 
         // -- Retrieve Environment variables from master
         EnvInjectLogger logger = new EnvInjectLogger(listener);
@@ -95,8 +92,7 @@ public class EnvInjectComputerListener extends ComputerListener implements Seria
         } 
         
         //Get env vars for the current node
-        Map<String, String> nodeEnvVars = nodePath.act(
-                new GetMasterEnvVars());
+        Map<String, String> nodeEnvVars = nodePath.act(new EnvInjectMasterEnvVarsRetriever());
 
         // -- Process slave properties
         boolean unsetSystemVariables = false;
@@ -183,11 +179,5 @@ public class EnvInjectComputerListener extends ComputerListener implements Seria
         }
         return false;
 
-    }
-
-    private static class GetMasterEnvVars extends MasterToSlaveCallable<Map<String, String>, IOException> {
-        public Map<String, String> call() throws IOException {
-            return EnvVars.masterEnvVars;
-        }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsRetriever.java
@@ -1,0 +1,17 @@
+package org.jenkinsci.plugins.envinject.service;
+
+import hudson.EnvVars;
+import jenkins.security.MasterToSlaveCallable;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Restricted(NoExternalUse.class)
+public class EnvInjectMasterEnvVarsRetriever extends MasterToSlaveCallable<Map<String, String>, IOException> {
+
+    public Map<String, String> call() throws IOException {
+        return EnvVars.masterEnvVars;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvironmentVariablesNodeLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvironmentVariablesNodeLoader.java
@@ -7,7 +7,6 @@ import hudson.model.Node;
 import hudson.model.Run;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
-import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 import org.jenkinsci.lib.envinject.EnvInjectLogger;
 
@@ -59,11 +58,8 @@ public class EnvironmentVariablesNodeLoader implements Serializable {
         Map<String, String> configNodeEnvVars = new HashMap<String, String>();
 
         try {
-
             //Get env vars for the current node
-            Map<String, String> nodeEnvVars = nodePath.act(
-                    new EnvVarMasterToSlaveCallable()
-            );
+            Map<String, String> nodeEnvVars = nodePath.act(new EnvInjectMasterEnvVarsRetriever());
 
             for (NodeProperty<?> nodeProperty : Jenkins.getActiveInstance().getGlobalNodeProperties()) {
                 if (nodeProperty instanceof EnvironmentVariablesNodeProperty) {
@@ -91,12 +87,6 @@ public class EnvironmentVariablesNodeLoader implements Serializable {
             throw new EnvInjectException(ioe);
         } catch (InterruptedException ie) {
             throw new EnvInjectException(ie);
-        }
-    }
-
-    private static class EnvVarMasterToSlaveCallable extends MasterToSlaveCallable<Map<String, String>, IOException> {
-        public Map<String, String> call() throws IOException {
-            return EnvVars.masterEnvVars;
         }
     }
 }


### PR DESCRIPTION
The warning from org.jenkinsci.remoting.util.AnonymousClassWarnings was:
> WARNING: Attempt to (de-)serialize anonymous class org.jenkinsci.plugins.envinject.EnvInjectComputerListener$1
> see: https://jenkins.io/redirect/serialization-of-anonymous-classes/

It seems this anonymous class was missed in #134 @jsoref.

Hopefully this is the last fix in this regard. At least for `Callable` it should be fine now (`grep -rP 'new.*Callable.*{' src/` does not find anything else).