### PR TITLE
Escape paths for network shares

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/PropertiesLoader.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.envinject.service;
 
-
 import hudson.Util;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 
@@ -11,6 +10,7 @@ import java.io.StringReader;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
+
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
@@ -72,6 +72,9 @@ public class PropertiesLoader implements Serializable {
         // Replace single backslashes with double ones so they won't be removed by Property.load()
         String escapedContent = content;
         escapedContent = escapedContent.replaceAll("(?<![\\\\])\\\\(?![n:*?\"<>\\\\/])(?![\\\\])(?![\n])", "\\\\\\\\");
+        //Escape windows network shares initial double backslash i.e \\Network\Share
+        escapedContent = escapedContent.replaceAll("(?m)^([^=]+=)(\\\\\\\\)(?![:*?\"<>\\\\/])", "$1\\\\\\\\\\\\\\\\");
+
         Map<String, String> result = new LinkedHashMap<>();
         
         Properties properties = new Properties();

--- a/src/test/java/org/jenkinsci/plugins/envinject/sevice/PropertiesLoaderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/sevice/PropertiesLoaderTest.java
@@ -173,13 +173,14 @@ public class PropertiesLoaderTest {
     }
 
     private void checkWithBackSlashes(boolean fromFile) throws Exception {
-        String content = "KEY1=Test\\Path\\Variable\nKEY2=C:\\Windows\\Temp";
+        String content = "KEY1=Test\\Path\\Variable\nKEY2=C:\\Windows\\Temp\nKEY3=\\\\Test\\Path\\Variable";
         Map<String, String> gatherVars = gatherEnvVars(fromFile, content, new HashMap<String, String>());
         assertNotNull(gatherVars);
-        assertEquals(2, gatherVars.size());
+        assertEquals(3, gatherVars.size());
 
         assertEquals("Test\\Path\\Variable", gatherVars.get("KEY1"));
         assertEquals("C:\\Windows\\Temp", gatherVars.get("KEY2"));
+        assertEquals("\\\\Test\\Path\\Variable", gatherVars.get("KEY3"));
     }
 
     private Map<String, String> gatherEnvVars(boolean fromFile, String content2Load, Map<String, String> currentEnvVars) throws Exception {


### PR DESCRIPTION
For windows paths #133 misses out the case of network shares where network shares begin with a double backslash. This PR adds that capability and a functional test for it.