### PR TITLE
Disabled autocomplete on Script File Path input

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectJobPropertyInfo/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/envinject/EnvInjectJobPropertyInfo/config.jelly
@@ -11,7 +11,8 @@
     </f:entry>
 
     <f:entry field="scriptFilePath"
-             title="${%Script File Path}">
+             title="${%Script File Path}"
+             autocomplete="off">
         <f:textbox/>
     </f:entry>
 


### PR DESCRIPTION
`Script File Path` input is being treated as a username autocomplete field. This seems to only be affecting Chrome browsers (tested on Version 77.0.3865.120).

This can result in the logged in user's username being filed in and results in the configuration breaking / needing to be reverted.

Unsure if this is the actual fix and has not been tested but would just like to bring this to your attention - apologies in advance if there is somewhere better to raise this!