### PR TITLE
JENKINS-60559: Log warning when not all environment variables can be injected

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectEnvVarsContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectEnvVarsContributor.java
@@ -6,15 +6,12 @@ import hudson.model.*;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.logging.Logger;
 
 /**
  * @since 1.92
  */
 @Extension
 public class EnvInjectEnvVarsContributor extends EnvironmentContributor {
-
-    private final static Logger LOGGER = Logger.getLogger(EnvInjectEnvVarsContributor.class.getName());
 
     @Override
     @SuppressWarnings("rawtypes")
@@ -30,7 +27,7 @@ public class EnvInjectEnvVarsContributor extends EnvironmentContributor {
                     int expectedEnvSize = env.size() + result.size();
                     env.putAll(result);
                     if (env.size() != expectedEnvSize) {
-                        LOGGER.warning("Not all environment variables could be successfully injected. " +
+                        listener.error("Not all environment variables could be successfully injected. " +
                                 "Check for similarly-named environment variables.");
                     }
                 }

--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectEnvVarsContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectEnvVarsContributor.java
@@ -6,12 +6,15 @@ import hudson.model.*;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  * @since 1.92
  */
 @Extension
 public class EnvInjectEnvVarsContributor extends EnvironmentContributor {
+
+    private final static Logger LOGGER = Logger.getLogger(EnvInjectEnvVarsContributor.class.getName());
 
     @Override
     @SuppressWarnings("rawtypes")
@@ -24,7 +27,12 @@ public class EnvInjectEnvVarsContributor extends EnvironmentContributor {
             if (jobPropertyInfo != null) {
                 Map<String, String> result = jobPropertyInfo.getPropertiesContentMap(env);
                 if (result != null) {
+                    int expectedEnvSize = env.size() + result.size();
                     env.putAll(result);
+                    if (env.size() != expectedEnvSize) {
+                        LOGGER.warning("Not all environment variables could be successfully injected. " +
+                                "Check for similarly-named environment variables.");
+                    }
                 }
             }
         }


### PR DESCRIPTION
When similarly-named environment variables with different case are defined as job properties, they will be treated as one variable and overwrite each other. `EnvVars` appears to treat variables in a case-insensitive manner by design, so if altering the existing behavior is not an option, a warning regarding this behavior should at least be logged to prevent confusion.