### PR TITLE
[JENKINS-64398] - Update EnvInject API to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <revision>2.4.1</revision>
         <changelist>-SNAPSHOT</changelist>
         <ivy.plugin.version>1.21</ivy.plugin.version>
-        <jenkins.version>2.264</jenkins.version>
+        <jenkins.version>2.266</jenkins.version>
         <java.level>8</java.level>
         <!-- Remove once JENKINS-45055 is fixed -->
         <spotbugs.failOnError>false</spotbugs.failOnError>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>envinject-api</artifactId>
-            <version>1.6</version>
+            <version>1.8</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Picks up https://github.com/jenkinsci/envinject-lib/pull/19 via https://github.com/jenkinsci/envinject-api-plugin/pull/17 and runs against a core JEP-228 to verify `EnvInjectVarListTest.envVarsShouldBeCachedProperlyAfterReload`.
