### PR TITLE
chore: Prepare for sunset icon removal from core

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectAction.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectAction.java
@@ -58,7 +58,7 @@ public class EnvInjectAction implements Action, StaplerProxy {
         if (!EnvInjectPlugin.canViewInjectedVars(build)) {
             return null;
         }
-        return "document-properties.gif";
+        return "document-properties.png";
     }
 
     @Override

--- a/src/main/resources/util/hetero-list-readonly.jelly
+++ b/src/main/resources/util/hetero-list-readonly.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
+         xmlns:f="/lib/form" xmlns:local="local">
     <st:documentation>
         Adapted from https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/lib/form/hetero-list.jelly
 
@@ -73,7 +73,7 @@ THE SOFTWARE.
                         <j:if test="${help!=null}">
                             <f:entry>
                                 <a href="#" class="help-button" helpURL="${rootURL}${help}">
-                                    <img src="${imagesURL}/16x16/help.gif" alt="[help]" height="16" width="16"/>
+                                    <l:icon class="icon-help icon-sm" alt="[help]" />
                                 </a>
                             </f:entry>
                         </j:if>


### PR DESCRIPTION
Preparation for core sunsetting dated icons: `https://github.com/jenkinsci/jenkins/pull/5778`

@oleg-nenashev Would be nice if you can also trigger a release after merging this PR. The core PR is blocked until then.
Thanks in advance!

(May dismiss if this plugin is actually no longer maintained, I was solely going of SCM activity)