### PR TITLE
[JENKINS-68930] Fix Java17 Error on agent start

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
@@ -7,7 +7,10 @@ import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.lib.envinject.EnvInjectException;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -21,6 +24,20 @@ public class EnvInjectMasterEnvVarsSetter extends MasterToSlaveCallable<Void, En
         this.enVars = enVars;
     }
 
+    private Field getModifiers() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method getDeclaredFields0 = Class.class.getDeclaredMethod("getDeclaredFields0", boolean.class);
+        getDeclaredFields0.setAccessible(true);
+        Field[] fields = (Field[]) getDeclaredFields0.invoke(Field.class, false);
+        Field modifiers = null;
+        for (Field each : fields) {
+            if ("modifiers".equals(each.getName())) {
+                modifiers = each;
+                break;
+            }
+        }
+        return modifiers;
+    }
+
     @Override
     public Void call() throws EnvInjectException {
         try {
@@ -32,7 +49,7 @@ public class EnvInjectMasterEnvVarsSetter extends MasterToSlaveCallable<Void, En
             }
             Field masterEnvVarsFiled = EnvVars.class.getDeclaredField("masterEnvVars");
             masterEnvVarsFiled.setAccessible(true);
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
+            Field modifiersField = getModifiers();
             modifiersField.setAccessible(true);
             modifiersField.setInt(masterEnvVarsFiled, masterEnvVarsFiled.getModifiers() & ~Modifier.FINAL);
             masterEnvVarsFiled.set(null, enVars);
@@ -40,6 +57,10 @@ public class EnvInjectMasterEnvVarsSetter extends MasterToSlaveCallable<Void, En
             throw new EnvInjectException(iae);
         } catch (NoSuchFieldException nsfe) {
             throw new EnvInjectException(nsfe);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
         }
 
         return null;

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
@@ -53,13 +53,9 @@ public class EnvInjectMasterEnvVarsSetter extends MasterToSlaveCallable<Void, En
             modifiersField.setAccessible(true);
             modifiersField.setInt(masterEnvVarsFiled, masterEnvVarsFiled.getModifiers() & ~Modifier.FINAL);
             masterEnvVarsFiled.set(null, enVars);
-        } catch (IllegalAccessException iae) {
+        } catch (IllegalAccessException | NoSuchFieldException iae) {
             throw new EnvInjectException(iae);
-        } catch (NoSuchFieldException nsfe) {
-            throw new EnvInjectException(nsfe);
-        } catch (InvocationTargetException e) {
-            throw new RuntimeException(e);
-        } catch (NoSuchMethodException e) {
+        } catch (InvocationTargetException | NoSuchMethodException e) {
             throw new RuntimeException(e);
         }
 

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
@@ -24,7 +24,7 @@ public class EnvInjectMasterEnvVarsSetter extends MasterToSlaveCallable<Void, En
         this.enVars = enVars;
     }
 
-    private Field getModifiers() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    private Field getModifiers() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException {
         Method getDeclaredFields0 = Class.class.getDeclaredMethod("getDeclaredFields0", boolean.class);
         getDeclaredFields0.setAccessible(true);
         Field[] fields = (Field[]) getDeclaredFields0.invoke(Field.class, false);
@@ -34,6 +34,9 @@ public class EnvInjectMasterEnvVarsSetter extends MasterToSlaveCallable<Void, En
                 modifiers = each;
                 break;
             }
+        }
+        if (modifiers == null) {
+            throw new NoSuchFieldException();
         }
         return modifiers;
     }


### PR DESCRIPTION
See [JENKINS-66896](https://issues.jenkins.io/browse/JENKINS-66896) and [JENKINS-68930](https://issues.jenkins.io/browse/JENKINS-68930)

Use WA to work with modifiers field filtered since JDK12.
--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED are required.
