### PR TITLE
Avoid unnecessary use of reflection

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectComputerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectComputerListener.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.envinject;
 
-import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Computer;
@@ -21,6 +20,8 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.model.Jenkins;
@@ -31,7 +32,7 @@ import jenkins.model.Jenkins;
 @Extension
 public class EnvInjectComputerListener extends ComputerListener implements Serializable {
 
-    private EnvVars getNewMasterEnvironmentVariables(@NonNull Computer c, 
+    private NavigableMap<String, String> getNewMasterEnvironmentVariables(@NonNull Computer c,
             @NonNull FilePath nodePath, @NonNull TaskListener listener) throws EnvInjectException, IOException, InterruptedException {
 
         //Get env vars for the current node
@@ -67,7 +68,7 @@ public class EnvInjectComputerListener extends ComputerListener implements Seria
         //Resolve against node env vars
         envInjectEnvVarsService.resolveVars(globalPropertiesEnvVars, nodeEnvVars);
 
-        EnvVars envVars2Set = new EnvVars();
+        NavigableMap<String, String> envVars2Set = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         if (!unsetSystemVariables) {
             envVars2Set.putAll(nodeEnvVars);
         }
@@ -76,7 +77,7 @@ public class EnvInjectComputerListener extends ComputerListener implements Seria
         return envVars2Set;
     }
 
-    private EnvVars getNewSlaveEnvironmentVariables(@NonNull Computer c, 
+    private NavigableMap<String, String> getNewSlaveEnvironmentVariables(@NonNull Computer c,
             @NonNull FilePath nodePath, @NonNull TaskListener listener) throws EnvInjectException, IOException, InterruptedException {
 
         Map<String, String> currentEnvVars = new HashMap<>();
@@ -114,7 +115,7 @@ public class EnvInjectComputerListener extends ComputerListener implements Seria
         //Resolve against node env vars
         envInjectEnvVarsService.resolveVars(currentEnvVars, nodeEnvVars);
 
-        EnvVars envVars2Set = new EnvVars();
+        NavigableMap<String, String> envVars2Set = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         if (!unsetSystemVariables) {
             envVars2Set.putAll(nodeEnvVars);
         }
@@ -140,7 +141,7 @@ public class EnvInjectComputerListener extends ComputerListener implements Seria
         if (isActiveSlave(c)) {
 
             try {
-                EnvVars envVars2Set = getNewSlaveEnvironmentVariables(c, nodePath, listener);
+                NavigableMap<String, String> envVars2Set = getNewSlaveEnvironmentVariables(c, nodePath, listener);
                 nodePath.act(new EnvInjectMasterEnvVarsSetter(envVars2Set));
             } catch (EnvInjectException e) {
                 throw new IOException(e);
@@ -151,7 +152,7 @@ public class EnvInjectComputerListener extends ComputerListener implements Seria
         //use case : it is only on master
         else if (isGlobalEnvInjectActivatedOnMaster()) {
             try {
-                EnvVars envVars2Set = getNewMasterEnvironmentVariables(c, nodePath, listener);
+                NavigableMap<String, String> envVars2Set = getNewMasterEnvironmentVariables(c, nodePath, listener);
                 nodePath.act(new EnvInjectMasterEnvVarsSetter(envVars2Set));
             } catch (EnvInjectException e) {
                 throw new IOException(e);

--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
@@ -1,15 +1,9 @@
 package org.jenkinsci.plugins.envinject.service;
 
 import hudson.EnvVars;
-import hudson.Main;
-import hudson.Platform;
+import java.util.NavigableMap;
 import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.lib.envinject.EnvInjectException;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -18,51 +12,15 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public class EnvInjectMasterEnvVarsSetter extends MasterToSlaveCallable<Void, EnvInjectException> {
 
-    private @NonNull EnvVars enVars;
+    private @NonNull NavigableMap<String, String> enVars;
 
-    public EnvInjectMasterEnvVarsSetter(@NonNull EnvVars enVars) {
+    public EnvInjectMasterEnvVarsSetter(@NonNull NavigableMap<String, String> enVars) {
         this.enVars = enVars;
     }
 
-    private Field getModifiers() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException {
-        Method getDeclaredFields0 = Class.class.getDeclaredMethod("getDeclaredFields0", boolean.class);
-        getDeclaredFields0.setAccessible(true);
-        Field[] fields = (Field[]) getDeclaredFields0.invoke(Field.class, false);
-        Field modifiers = null;
-        for (Field each : fields) {
-            if ("modifiers".equals(each.getName())) {
-                modifiers = each;
-                break;
-            }
-        }
-        if (modifiers == null) {
-            throw new NoSuchFieldException();
-        }
-        return modifiers;
-    }
-
     @Override
-    public Void call() throws EnvInjectException {
-        try {
-            Field platformField = EnvVars.class.getDeclaredField("platform");
-            platformField.setAccessible(true);
-            platformField.set(enVars, Platform.current());
-            if (Main.isUnitTest || Main.isDevelopmentMode) {
-                enVars.remove("MAVEN_OPTS");
-            }
-            Field masterEnvVarsFiled = EnvVars.class.getDeclaredField("masterEnvVars");
-            masterEnvVarsFiled.setAccessible(true);
-            Field modifiersField = getModifiers();
-            modifiersField.setAccessible(true);
-            modifiersField.setInt(masterEnvVarsFiled, masterEnvVarsFiled.getModifiers() & ~Modifier.FINAL);
-            masterEnvVarsFiled.set(null, enVars);
-        } catch (IllegalAccessException | NoSuchFieldException iae) {
-            throw new EnvInjectException(iae);
-        } catch (InvocationTargetException | NoSuchMethodException e) {
-            throw new RuntimeException(e);
-        }
-
+    public Void call() {
+        EnvVars.masterEnvVars.putAll(enVars);
         return null;
     }
-
 }


### PR DESCRIPTION
I saw the recent changes to make this plugin work on Java 17 but I was a bit dissatisfied with having to add `--add-opens` arguments. I think the plugin can be simplified to avoid the use of reflection entirely, which simplifies maintenance and obviates the need for `--add-opens` directives.

I tested this by running the automated tests and doing some basic tests locally on both the controller and on an agent, but I have not done very exhaustive manual testing and this code is very fragile, so I would appreciate any additional testing that others can offer. @bulanovk are you interested in testing this out in production for a week or so and reporting back if there are any issues?