### PR TITLE
[JENKINS-71658] Update plugin dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,31 +86,6 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <!--
-                TODO script-security 1172.v35f6a_0b_8207e breaks
-                EnvInjectEvaluatedGroovyScriptTest#testWorkaroundSecurity86, so downgrade it to the
-                last working version along with anything that depends on the newer broken version
-            -->
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>junit</artifactId>
-                <version>1.63</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>matrix-project</artifactId>
-                <version>771.v574584b_39e60</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>script-security</artifactId>
-                <version>1158.v7c1b_73a_69a_08</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                <artifactId>workflow-support</artifactId>
-                <version>820.vd1a_6cc65ef33</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/src/test/java/org/jenkinsci/plugins/envinject/util/TestUtils.java
+++ b/src/test/java/org/jenkinsci/plugins/envinject/util/TestUtils.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.envinject.util;
 
 import hudson.model.FreeStyleProject;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.htmlunit.html.HtmlForm;
 import org.jvnet.hudson.test.JenkinsRule;
 
 /**
@@ -19,6 +20,9 @@ public class TestUtils {
      */
     public static void saveConfigurationAs(@NonNull JenkinsRule jenkins, @NonNull FreeStyleProject project, @NonNull String userId) throws Exception {
         JenkinsRule.WebClient w = jenkins.createWebClient().login(userId);
-        jenkins.submit(w.getPage(project, "configure").getFormByName("config"));
+        final HtmlForm formByName = w.getPage(project, "configure").getFormByName("config");
+        // Workaround for SECURITY-2450 in Script Security 1172.v35f6a_0b_8207e and newer
+        formByName.getInputsByName("oldScript").forEach(input -> input.setValue("different value to force behavior when modified"));
+        jenkins.submit(formByName);
     }
 }


### PR DESCRIPTION
Remove locked dependencies from https://github.com/jenkinsci/envinject-plugin/pull/268 after adapting tests to make them pass. This updates some plugin dependencies.

See [JENKINS-71658](https://issues.jenkins.io/browse/JENKINS-71658).

### Testing done

Ran autotests only, as this is a test-only issue.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
