### PR TITLE
Improve Error Message for Environment Variable Injection Conflicts

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectEnvVarsContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/EnvInjectEnvVarsContributor.java
@@ -27,8 +27,8 @@ public class EnvInjectEnvVarsContributor extends EnvironmentContributor {
                     int expectedEnvSize = env.size() + result.size();
                     env.putAll(result);
                     if (env.size() != expectedEnvSize) {
-                        listener.error("Not all environment variables could be successfully injected. " +
-                                "Check for similarly-named environment variables.");
+                        listener.error("Some environment variables were not successfully injected. " +
+                                "This may be due to conflicts with existing environment variables that have the same name.");
                     }
                 }
             }


### PR DESCRIPTION
This PR improves the error message logged when not all environment variables can be successfully injected. I believe the updated message provides clearer information about potential conflicts with existing environment variables that may have the same name.

The cause of this error was not immediately obvious to me when reviewing failures in Jenkins output - so this is just a slight improvement to the error message (subjective).

### Changes:
* Updated the error message in EnvInjectEnvVarsContributor.java to clarify that conflicts with existing environment variables may be the reason for injection failures.

### Testing done

No logic changes - just error output. Tests already exist for this functionality.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira 
    -  None
- [x] Link to relevant pull requests, esp. upstream and downstream changes 
    - None
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue 
    - Existing tests cover these lines
