### PR TITLE
Reduce the use of reflection in some rare circumstances

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
+++ b/src/main/java/org/jenkinsci/plugins/envinject/service/EnvInjectMasterEnvVarsSetter.java
@@ -43,6 +43,18 @@ public class EnvInjectMasterEnvVarsSetter extends MasterToSlaveCallable<Void, En
 
     @Override
     public Void call() throws EnvInjectException {
+        if (EnvVars.masterEnvVars.equals(enVars)) {
+            // Nothing to update
+            return null;
+        } else if (EnvVars.masterEnvVars.keySet().equals(enVars.keySet())) {
+           /*
+            * Per the Javadoc, merely changing the value associated with an existing key is not a structural
+            * modification and thus does not require synchronization.
+            */
+           EnvVars.masterEnvVars.putAll(enVars);
+           return null;
+        }
+
         try {
             Field platformField = EnvVars.class.getDeclaredField("platform");
             platformField.setAccessible(true);


### PR DESCRIPTION
Very slightly mitigates the impact of [JENKINS-60891](https://issues.jenkins.io/browse/JENKINS-60891) in two rather rare circumstances: when the environment is not changing, and when an existing variable is being updated. This is far from a solution to JENKINS-60891, but at least it's better than nothing. A full solution would require core changes and adaptations in several other plugins, which would be a much larger effort. Meanwhile, this can't hurt and is better than the status quo.

### Testing done

Manually tested that overriding the `PATH` parameter failed before this PR and succeeded after this PR on Java 17.